### PR TITLE
Default site code, external status codes and empty attributes

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -196,6 +196,12 @@ has service_request_content => (
     default => '/open311/service_request_extended'
 );
 
+has default_site_code => (
+    is => 'ro',
+    default => ''
+);
+
+
 sub process_service_request_args {
     my $self = shift;
     my $args = shift;
@@ -216,6 +222,12 @@ sub process_service_request_args {
 
     if (my $assigned_officer = $self->service_assigned_officers->{$args->{service_code}}) {
         $args->{assigned_officer} = $assigned_officer;
+    }
+
+    # Some Confirm installations should have enquiries matched against a
+    # default SiteCode if it wasn't specified from FMS.
+    if (!$args->{site_code} && $self->default_site_code) {
+        $args->{site_code} = $self->default_site_code;
     }
 
     # Open311 doesn't support a 'title' field for service requests, so FMS

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -18,7 +18,7 @@ use SOAP::Lite; # +trace => [ qw/method debug/ ];
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
     die unless $args{jurisdiction_id}; # Must have one by here
-    $args{config_file} = path(__FILE__)->parent(5)->realpath->child("conf/council-$args{jurisdiction_id}.yml")->stringify;
+    $args{config_file} //= path(__FILE__)->parent(5)->realpath->child("conf/council-$args{jurisdiction_id}.yml")->stringify;
     return $class->$orig(%args);
 };
 

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -338,6 +338,7 @@ sub get_service_request_updates {
                 service_request_id => $enquiry_id,
                 description => $description,
                 updated_datetime => $ts,
+                external_status_code => $status_log->{EnquiryStatusCode},
             );
         }
     }

--- a/perllib/Open311/Endpoint/Role/mySociety.pm
+++ b/perllib/Open311/Endpoint/Role/mySociety.pm
@@ -183,7 +183,15 @@ sub format_updates {
                             service_request_id
                             status
                             description
-                            / 
+                            /
+                    ),
+                    (
+                        map {
+                            ($update->can($_) && $update->$_ )? ($_ => $update->$_) : (),
+                        }
+                        qw/
+                            external_status_code
+                            /
                     ),
                     (
                         map {
@@ -258,6 +266,9 @@ sub learn_additional_types {
                 updated_datetime => '/open311/datetime',
                 description => '//str',
                 media_url => '//str',
+            },
+            optional => {
+                external_status_code => '//str',
             },
         }
     );

--- a/perllib/Open311/Endpoint/Service/Attribute.pm
+++ b/perllib/Open311/Endpoint/Service/Attribute.pm
@@ -74,6 +74,10 @@ sub schema_definition {
     my $self = shift;
 
     my @values = map +{ type => '//str', value => $_ }, $self->get_values;
+    # FMS will send a blank string for optional singlevaluelist attributes where
+    # the user didn't make a selection. Make sure this is allowed by the schema.
+    push(@values, { type => '//str', value => '' }) unless $self->required;
+
     my %schema_types = (
         string => '//str',
         number => '//num',

--- a/perllib/Open311/Endpoint/Service/Request/Update/mySociety.pm
+++ b/perllib/Open311/Endpoint/Service/Request/Update/mySociety.pm
@@ -21,5 +21,10 @@ has status => (
     ],
 );
 
+has external_status_code => (
+    is => 'ro',
+    isa => Maybe[Str],
+);
+
 
 1;

--- a/script/test
+++ b/script/test
@@ -3,4 +3,4 @@
 set -e
 cd "$(dirname "$0")/.."
 
-prove -Ilocal/lib/perl5 -Iperllib -r t/*
+prove -Ilocal/lib/perl5 -Iperllib -r $@

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -256,6 +256,7 @@ my $expected = <<XML;
 <service_request_updates>
   <request_update>
     <description></description>
+    <external_status_code>INP</external_status_code>
     <media_url></media_url>
     <service_request_id>2001</service_request_id>
     <status>in_progress</status>
@@ -264,6 +265,7 @@ my $expected = <<XML;
   </request_update>
   <request_update>
     <description></description>
+    <external_status_code>DUP</external_status_code>
     <media_url></media_url>
     <service_request_id>2002</service_request_id>
     <status>duplicate</status>

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -1,0 +1,277 @@
+package Integrations::Confirm::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Integrations::Confirm';
+with 'Role::Config';
+has config_filename => ( is => 'ro', default => 'dummy' );
+sub _build_config_file { path(__FILE__)->sibling("confirm.yml")->stringify }
+
+package Open311::Endpoint::Integration::UK::Dummy;
+use Moo;
+extends 'Open311::Endpoint::Integration::Confirm';
+has integration_class => (is => 'ro', default => 'Integrations::Confirm::Dummy');
+
+
+package main;
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::LongString;
+use Test::MockModule;
+
+use JSON::MaybeXS;
+use Path::Tiny;
+
+my ($IC, $SIC, $DC);
+
+my $open311 = Test::MockModule->new('Integrations::Confirm');
+$open311->mock(perform_request => sub {
+    my ($self, $op) = @_; # Don't care about subsequent ops
+    $op = $$op;
+    if ($op->name && $op->name eq 'GetEnquiryLookups') {
+        return {
+            OperationResponse => { GetEnquiryLookupsResponse => { TypeOfService => [
+                { ServiceCode => 'ABC', ServiceName => 'Graffiti', EnquirySubject => [ { SubjectCode => "DEF" } ] }
+            ] } }
+        };
+    }
+    $op = $op->value;
+    if ($op->name eq 'NewEnquiry') {
+        # Check contents of req here
+        return { OperationResponse => { NewEnquiryResponse => { Enquiry => { EnquiryNumber => 2001 } } } };
+    } elsif ($op->name eq 'EnquiryUpdate') {
+        # Check contents of req here
+        return { OperationResponse => { EnquiryUpdateResponse => { Enquiry => { EnquiryNumber => 2001, EnquiryLogNumber => 2 } } } };
+    } elsif ($op->name eq 'GetEnquiryStatusChanges') {
+        return { OperationResponse => { GetEnquiryStatusChangesResponse => { UpdatedEnquiry => [
+            { EnquiryNumber => 2001, EnquiryStatusLog => [ { EnquiryLogNumber => 3, LogEffectiveTime => '2018-03-01T12:00:00Z', EnquiryStatusCode => 'INP' } ] },
+            { EnquiryNumber => 2002, EnquiryStatusLog => [ { EnquiryLogNumber => 1, LogEffectiveTime => '2018-03-01T13:00:00Z', EnquiryStatusCode => 'DUP' } ] },
+        ] } } };
+    }
+    return {};
+});
+
+use Open311::Endpoint::Integration::UK::Dummy;
+
+my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new(
+    jurisdiction_id => 'dummy',
+    config_file => path(__FILE__)->sibling("confirm.yml")->stringify,
+);
+
+subtest "GET Service List" => sub {
+    my $res = $endpoint->run_test_request( GET => '/services.xml' );
+    ok $res->is_success, 'xml success';
+    my $expected = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<services>
+  <service>
+    <description>Flooding</description>
+    <group>Flooding &amp; Drainage</group>
+    <keywords></keywords>
+    <metadata>true</metadata>
+    <service_code>ABC_DEF</service_code>
+    <service_name>Flooding</service_name>
+    <type>realtime</type>
+  </service>
+</services>
+XML
+    is $res->content, $expected
+        or diag $res->content;
+};
+
+subtest "GET Service List Description" => sub {
+    my $res = $endpoint->run_test_request( GET => '/services/ABC_DEF.xml' );
+    ok $res->is_success, 'xml success';
+    my $expected = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_definition>
+  <attributes>
+    <attribute>
+      <automated>server_set</automated>
+      <code>easting</code>
+      <datatype>number</datatype>
+      <datatype_description></datatype_description>
+      <description>easting</description>
+      <order>1</order>
+      <required>true</required>
+      <variable>false</variable>
+    </attribute>
+    <attribute>
+      <automated>server_set</automated>
+      <code>northing</code>
+      <datatype>number</datatype>
+      <datatype_description></datatype_description>
+      <description>northing</description>
+      <order>2</order>
+      <required>true</required>
+      <variable>false</variable>
+    </attribute>
+    <attribute>
+      <automated>server_set</automated>
+      <code>fixmystreet_id</code>
+      <datatype>string</datatype>
+      <datatype_description></datatype_description>
+      <description>external system ID</description>
+      <order>3</order>
+      <required>true</required>
+      <variable>false</variable>
+    </attribute>
+    <attribute>
+      <automated>server_set</automated>
+      <code>report_url</code>
+      <datatype>string</datatype>
+      <datatype_description></datatype_description>
+      <description>Report URL</description>
+      <order>4</order>
+      <required>true</required>
+      <variable>true</variable>
+    </attribute>
+    <attribute>
+      <automated>server_set</automated>
+      <code>title</code>
+      <datatype>string</datatype>
+      <datatype_description></datatype_description>
+      <description>Title</description>
+      <order>5</order>
+      <required>true</required>
+      <variable>true</variable>
+    </attribute>
+    <attribute>
+      <automated>server_set</automated>
+      <code>description</code>
+      <datatype>text</datatype>
+      <datatype_description></datatype_description>
+      <description>Description</description>
+      <order>6</order>
+      <required>true</required>
+      <variable>true</variable>
+    </attribute>
+    <attribute>
+      <automated>hidden_field</automated>
+      <code>asset_details</code>
+      <datatype>text</datatype>
+      <datatype_description></datatype_description>
+      <description>Asset information</description>
+      <order>7</order>
+      <required>false</required>
+      <variable>true</variable>
+    </attribute>
+    <attribute>
+      <automated>hidden_field</automated>
+      <code>site_code</code>
+      <datatype>text</datatype>
+      <datatype_description></datatype_description>
+      <description>Site code</description>
+      <order>8</order>
+      <required>false</required>
+      <variable>true</variable>
+    </attribute>
+    <attribute>
+      <automated>hidden_field</automated>
+      <code>central_asset_id</code>
+      <datatype>string</datatype>
+      <datatype_description></datatype_description>
+      <description>Central Asset ID</description>
+      <order>9</order>
+      <required>false</required>
+      <variable>true</variable>
+    </attribute>
+  </attributes>
+  <service_code>ABC_DEF</service_code>
+</service_definition>
+XML
+    is $res->content, $expected
+        or diag $res->content;
+};
+
+subtest "POST OK" => sub {
+    $IC = 'CS';
+    $SIC = 'DP';
+    $DC = 'OTS';
+    my $res = $endpoint->run_test_request( 
+        POST => '/requests.json', 
+        api_key => 'test',
+        service_code => 'ABC_DEF',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the details",
+        'attribute[easting]' => 100,
+        'attribute[northing]' => 100,
+        'attribute[fixmystreet_id]' => 1001,
+        'attribute[title]' => 'Title',
+        'attribute[description]' => 'This is the details',
+        'attribute[report_url]' => 'http://example.com/report/1001',
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => 2001
+        } ], 'correct json returned';
+};
+
+subtest 'POST update' => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/servicerequestupdates.xml',
+        api_key => 'test',
+        service_request_id => 1001,
+        update_id => 123,
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => 'Update here',
+        status => 'OPEN',
+        updated_datetime => '2016-09-01T15:00:00Z',
+        media_url => 'http://example.org/',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+
+my $expected = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_request_updates>
+  <request_update>
+    <update_id>2001_2</update_id>
+  </request_update>
+</service_request_updates>
+XML
+
+    is_string $res->content, $expected, 'xml string ok'
+    or diag $res->content;
+};
+
+subtest 'GET update' => sub {
+    my $res = $endpoint->run_test_request(
+        GET => '/servicerequestupdates.xml?start_date=2018-01-01T00:00:00Z&end_date=2018-02-01T00:00:00Z',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+
+my $expected = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_request_updates>
+  <request_update>
+    <description></description>
+    <media_url></media_url>
+    <service_request_id>2001</service_request_id>
+    <status>in_progress</status>
+    <update_id>2001_3</update_id>
+    <updated_datetime>2018-03-01T12:00:00+00:00</updated_datetime>
+  </request_update>
+  <request_update>
+    <description></description>
+    <media_url></media_url>
+    <service_request_id>2002</service_request_id>
+    <status>duplicate</status>
+    <update_id>2002_1</update_id>
+    <updated_datetime>2018-03-01T13:00:00+00:00</updated_datetime>
+  </request_update>
+</service_request_updates>
+XML
+
+    is_string $res->content, $expected, 'xml string ok'
+    or diag $res->content;
+};
+
+done_testing;

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -39,7 +39,10 @@ $open311->mock(perform_request => sub {
     }
     $op = $op->value;
     if ($op->name eq 'NewEnquiry') {
-        # Check contents of req here
+        # Check more contents of req here
+        foreach (${$op->value}->value) {
+            is $_->value, 999999 if $_->name eq 'SiteCode';
+        }
         return { OperationResponse => { NewEnquiryResponse => { Enquiry => { EnquiryNumber => 2001 } } } };
     } elsif ($op->name eq 'EnquiryUpdate') {
         # Check contents of req here

--- a/t/open311/endpoint/confirm.yml
+++ b/t/open311/endpoint/confirm.yml
@@ -1,0 +1,11 @@
+endpoint_url: "http://example.org/endpoint"
+username: "username"
+password: "pw"
+tenant_id: "123"
+server_timezone: Europe/London
+service_whitelist:
+  Flooding & Drainage:
+    ABC_DEF: Flooding
+reverse_status_mapping:
+  DUP: duplicate
+  INP: in_progress

--- a/t/open311/endpoint/confirm.yml
+++ b/t/open311/endpoint/confirm.yml
@@ -3,6 +3,7 @@ username: "username"
 password: "pw"
 tenant_id: "123"
 server_timezone: Europe/London
+default_site_code: 999999
 service_whitelist:
   Flooding & Drainage:
     ABC_DEF: Flooding


### PR DESCRIPTION
Some improvements to the Confirm integration:

 - Subclasses can specify a default `SiteCode` if it's not passed in as a service request attribute.
 - The Confirm enquiry's `StatusCode` is exposed as `external_status_code` in `/servicerequestupdates.xml` output (to allow FMS to trigger response templates based on its value).
 - Correctly handle optional `singlevaluelist` attributes that are sent from FMS with an empty value.

Fixes #11.