### PR TITLE
[Confirm] Set requested_/updated_datetime of fetched requests correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - cp conf/general.yml-example conf/general.yml
   - cp conf/council-banes_confirm.yml-example conf/council-banes_confirm.yml
   - cp conf/council-buckinghamshire_confirm.yml-example conf/council-buckinghamshire_confirm.yml
+  - cp conf/council-lincolnshire_confirm.yml-example conf/council-lincolnshire_confirm.yml
   - 'if [ "$TRAVIS_PERL_VERSION" = "5.24" ]; then export HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,local/lib/perl5,^t"; fi'
 script:
   - script/test

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -576,17 +576,20 @@ sub get_service_requests {
             next;
         }
 
-        my $logtime = $self->date_parser->parse_datetime($enquiry->{EnquiryLogTime});
-        $logtime->set_time_zone($integ->server_timezone);
-        next if $self->cutoff_enquiry_date && $logtime < $self->cutoff_enquiry_date;
+        my $createdtime = $self->date_parser->parse_datetime($enquiry->{EnquiryLogTime});
+        $createdtime->set_time_zone($integ->server_timezone);
+        next if $self->cutoff_enquiry_date && $createdtime < $self->cutoff_enquiry_date;
+
+        my $updatedtime = $self->date_parser->parse_datetime($enquiry->{LogEffectiveTime});
+        $updatedtime->set_time_zone($integ->server_timezone);
 
         my $request = $self->new_request(
             service => $service,
             service_request_id => $enquiry->{EnquiryNumber},
             description => $enquiry->{EnquiryDescription},
             address => $enquiry->{EnquiryLocation} || '',
-            requested_datetime => $logtime,
-            updated_datetime => $logtime,
+            requested_datetime => $createdtime,
+            updated_datetime => $updatedtime,
             # NB: these are EPSG:27700 easting/northing
             latlong => [ $enquiry->{EnquiryY}, $enquiry->{EnquiryX} ],
             status => $status,


### PR DESCRIPTION
Fetched enquiries were being presented with the original logged time
as their created & last updated values. This meant FMS was ignoring
reports which were recently updated but opened before the 1-hour window
when fetching reports.

The enquiry fetching code could do with some tests, but after battling for too long to get it working I wanted to get this fix deployed to stop the cron emails.

Fixes mysociety/fixmystreet-commercial#1143.