### PR TITLE
Use LoggedTime, not LogEffectiveTime, for fetched requests

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -580,7 +580,7 @@ sub get_service_requests {
         $createdtime->set_time_zone($integ->server_timezone);
         next if $self->cutoff_enquiry_date && $createdtime < $self->cutoff_enquiry_date;
 
-        my $updatedtime = $self->date_parser->parse_datetime($enquiry->{LogEffectiveTime});
+        my $updatedtime = $self->date_parser->parse_datetime($enquiry->{LoggedTime});
         $updatedtime->set_time_zone($integ->server_timezone);
 
         my $request = $self->new_request(


### PR DESCRIPTION
The Confirm call to GetEnquiryStatusChanges filters on LoggedTime, and
it's possible for returned Enquiries to have a LogEffectiveTime outside
of the start/end times. Using LoggedTime instead of LogEffectiveTime as
the updated_datetime field for fetched requests ensures the values are
within the requested parameters.