### PR TITLE
[Rutland] fix issue with unicode characters in updates

### DIFF
--- a/perllib/Open311/Endpoint/Integration/SalesForce.pm
+++ b/perllib/Open311/Endpoint/Integration/SalesForce.pm
@@ -11,6 +11,7 @@ use Open311::Endpoint::Service::Request::Update::mySociety;
 
 use Integrations::SalesForce;
 
+use Encode qw(encode_utf8);
 use Digest::MD5 qw(md5_hex);
 use DateTime::Format::Strptime;
 
@@ -66,7 +67,8 @@ sub post_service_request_update {
 
     return undef unless $response;
 
-    my $digest = md5_hex($args->{description});
+    # md5 doesn't cope with unicode so need to turn to bytes
+    my $digest = md5_hex(encode_utf8($args->{description}));
     my $update_id = $response . '_' . $digest;
 
     return Open311::Endpoint::Service::Request::Update::mySociety->new(


### PR DESCRIPTION
we use md5 hashes as part of the update id and Digest::MD5 does not like
unicode strings so we have to encode them as bytes before passing in to
md5_hex