### PR TITLE
Allow setting all fetched reports to be marked private in Confirm integrations

### DIFF
--- a/perllib/Open311/Endpoint/Role/mySociety.pm
+++ b/perllib/Open311/Endpoint/Role/mySociety.pm
@@ -299,6 +299,7 @@ sub learn_additional_types {
                 description => '//str',
                 agency_responsible => '//str',
                 service_notice => '//str',
+                non_public => '//str',
             },
         }
     );

--- a/perllib/Open311/Endpoint/Service/Request/CanBeNonPublic.pm
+++ b/perllib/Open311/Endpoint/Service/Request/CanBeNonPublic.pm
@@ -1,0 +1,22 @@
+package Open311::Endpoint::Service::Request::CanBeNonPublic;
+use Moo;
+use MooX::HandlesVia;
+extends 'Open311::Endpoint::Service::Request::ExtendedStatus';
+
+use DateTime;
+use Types::Standard ':all';
+
+has 'optional_fields' => (
+    is => 'ro',
+    isa => ArrayRef[ Str ],
+    default => sub { [ 'non_public' ] },
+);
+
+has non_public => (
+    is => 'ro',
+    isa => Str,
+    default => 0
+);
+
+
+1;

--- a/t/open311/endpoint/confirm_private.yml
+++ b/t/open311/endpoint/confirm_private.yml
@@ -1,0 +1,14 @@
+endpoint_url: "http://example.org/endpoint"
+username: "username"
+password: "pw"
+tenant_id: "123"
+server_timezone: Europe/London
+default_site_code: 999999
+service_whitelist:
+  Flooding & Drainage:
+    ABC_DEF: Flooding
+reverse_status_mapping:
+  DUP: duplicate
+  INP: in_progress
+cutoff_enquiry_date: 2018-04-12T12:00:00
+fetch_reports_private: 1


### PR DESCRIPTION
If `fetch_reports_private` is set in the config file then include a `non_public` field set to 1 in the XML returned by `get_service_requests`. 