### PR TITLE
[Confirm] truncate all times to seconds

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -427,7 +427,7 @@ sub get_service_request_updates {
         for my $status_log (@$status_logs) {
             my $enquiry_id = $enquiry->{EnquiryNumber};
             my $update_id = $enquiry_id . "_" . $status_log->{EnquiryLogNumber};
-            my $ts = $self->date_parser->parse_datetime($status_log->{LoggedTime});
+            my $ts = $self->date_parser->parse_datetime($status_log->{LoggedTime})->truncate( to => 'second' );
             $ts->set_time_zone($integ->server_timezone);
             my $description = $self->publish_service_update_text ?
                 ($status_log->{StatusLogNotes} || "") :
@@ -581,11 +581,11 @@ sub get_service_requests {
             next;
         }
 
-        my $createdtime = $self->date_parser->parse_datetime($enquiry->{EnquiryLogTime});
+        my $createdtime = $self->date_parser->parse_datetime($enquiry->{EnquiryLogTime})->truncate( to => 'second' );
         $createdtime->set_time_zone($integ->server_timezone);
         next if $self->cutoff_enquiry_date && $createdtime < $self->cutoff_enquiry_date;
 
-        my $updatedtime = $self->date_parser->parse_datetime($enquiry->{LoggedTime});
+        my $updatedtime = $self->date_parser->parse_datetime($enquiry->{LoggedTime})->truncate( to => 'second' );
         $updatedtime->set_time_zone($integ->server_timezone);
 
         my %args = (

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -85,7 +85,7 @@ $open311->mock(perform_request => sub {
         return { OperationResponse => { GetEnquiryStatusChangesResponse => { UpdatedEnquiry => [
             { EnquiryNumber => 2001, EnquiryStatusLog => [ { EnquiryLogNumber => 3, LogEffectiveTime => '2018-03-01T12:00:00Z', LoggedTime => '2018-03-01T12:00:00Z', EnquiryStatusCode => 'INP' } ] },
             { EnquiryNumber => 2002, EnquiryStatusLog => [ { EnquiryLogNumber => 1, LogEffectiveTime => '2018-03-01T13:00:00Z', LoggedTime => '2018-03-01T13:00:00Z', EnquiryStatusCode => 'INP' } ] },
-            { EnquiryNumber => 2002, EnquiryStatusLog => [ { EnquiryLogNumber => 2, LogEffectiveTime => '2018-01-17T12:34:56Z', LoggedTime => '2018-03-01T13:30:00Z', EnquiryStatusCode => 'DUP' } ] },
+            { EnquiryNumber => 2002, EnquiryStatusLog => [ { EnquiryLogNumber => 2, LogEffectiveTime => '2018-01-17T12:34:56Z', LoggedTime => '2018-03-01T13:30:00.4000Z', EnquiryStatusCode => 'DUP' } ] },
         ] } } };
     }
     return {};


### PR DESCRIPTION
Sometimes confirm includes microseconds in datetimes which fails the
validator so truncate all datetimes to seconds.