### PR TITLE
[Alloy] only set description if customer comments changes

### DIFF
--- a/t/open311/endpoint/alloy.t
+++ b/t/open311/endpoint/alloy.t
@@ -117,6 +117,12 @@ $integration->mock('api_call', sub {
             $content = path(__FILE__)->sibling('json/alloy/resource_versions.json')->slurp;
         } elsif ( $call eq 'resource/4947502/versions' ) {
             $content = path(__FILE__)->sibling('json/alloy/resource_versions_4947502.json')->slurp;
+        } elsif ( $call eq 'resource/3027030/versions' ) {
+            $content = path(__FILE__)->sibling('json/alloy/resource_versions_3027030.json')->slurp;
+        } elsif ( $call eq 'resource/3027029/full?systemVersion=272125' ) {
+            $content = path(__FILE__)->sibling('json/alloy/resource_3027029_v272125.json')->slurp;
+        } elsif ( $call eq 'resource/3027030/full?systemVersion=271881' ) {
+            $content = path(__FILE__)->sibling('json/alloy/resource_3027030_v271881.json')->slurp;
         } elsif ( $call eq 'resource/1' ) {
             $content = '{ "sourceTypeId": 800 }';
         } elsif ( $call eq 'source-type/800/linked-source-types' ) {
@@ -300,9 +306,17 @@ subtest "check fetch updates" => sub {
     [ {
         status => 'investigating',
         service_request_id => '3027029',
-        description => '',
+        description => 'This is a customer response',
         updated_datetime => '2019-01-01T01:59:40Z',
         update_id => '271882',
+        media_url => '',
+    },
+    {
+        status => 'investigating',
+        service_request_id => '3027030',
+        description => '',
+        updated_datetime => '2019-01-01T01:59:40Z',
+        update_id => '271883',
         media_url => '',
     },
     {

--- a/t/open311/endpoint/json/alloy/inspect_search.json
+++ b/t/open311/endpoint/json/alloy/inspect_search.json
@@ -49,6 +49,11 @@
           "value": "INS-00009033"
         },
         {
+          "attributeId": 1011096,
+          "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_-_ENQUIRY_-_REQUEST_FOR_SERVICE_RESPONSE_TO_CUSTOMER",
+          "value": "This is a customer response"
+        },
+        {
           "attributeId": 1001546,
           "attributeCode": "GRP_PROJECT_TASK_ATT_PROJECT_TASK_STATUS",
           "value": {
@@ -96,6 +101,105 @@
         "startSystemVersionId": 268108,
         "usedDate": "2019-02-19T18:19:14.543Z",
         "usedSystemVersionId": 271882
+      }
+    },
+    {
+      "colour": "#DF412C",
+      "geometry": {
+        "digiLength": null,
+        "lod16BboxIntMaxX": -210,
+        "lod16BboxIntMaxY": -11206,
+        "lod16BboxIntMinX": -210,
+        "lod16BboxIntMinY": -11207,
+        "featureGeom": {
+          "type": "Feature",
+          "id": "3027029",
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [
+              [
+                -128047.3,
+                6852412.2
+              ],
+              [
+                -128014,
+                6852447.9
+              ]
+            ]
+          },
+          "properties": {},
+          "crs": {
+            "properties": {
+              "name": "EPSG:900913"
+            },
+            "type": "name"
+          }
+        }
+      },
+      "itemId": 3099981,
+      "resourceId": 3027030,
+      "sourceId": 2320,
+      "sourceTypeId": 1001181,
+      "title": "INS-00009034",
+      "values": [
+        {
+          "attributeId": 1003787,
+          "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_NUMBER",
+          "value": "INS-00009034"
+        },
+        {
+          "attributeId": 1011096,
+          "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_-_ENQUIRY_-_REQUEST_FOR_SERVICE_RESPONSE_TO_CUSTOMER",
+          "value": "This is a customer response"
+        },
+        {
+          "attributeId": 1001546,
+          "attributeCode": "GRP_PROJECT_TASK_ATT_PROJECT_TASK_STATUS",
+          "value": {
+            "parentReferenceContainerId": null,
+            "systemVersion": {
+              "allReferencesId": null,
+              "allResourcesId": null,
+              "childSummaryId": null
+            },
+            "values": [
+              {
+                "referenceId": 298204,
+                "resourceId": 2,
+                "sourceId": null
+              }
+            ]
+          }
+        },
+        {
+          "attributeId": 1001825,
+          "attributeCode": "GRP_INSPECTION_STANDARD_ATT_TEAM",
+          "value": {
+            "parentReferenceContainerId": null,
+            "systemVersion": {
+              "allReferencesId": null,
+              "allResourcesId": null,
+              "childSummaryId": null
+            },
+            "values": [
+              {
+                "referenceId": 291702,
+                "resourceId": 743500,
+                "sourceId": null
+              }
+            ]
+          }
+        }
+      ],
+      "version": {
+        "currentSystemVersionId": 271883,
+        "endDate": "9999-12-31T00:00:00.000Z",
+        "endSystemVersionId": null,
+        "resourceSystemVersionId": 271883,
+        "startDate": "2014-01-01T11:59:40Z",
+        "startSystemVersionId": 268108,
+        "usedDate": "2019-02-19T18:19:14.543Z",
+        "usedSystemVersionId": 271883
       }
     }
   ]

--- a/t/open311/endpoint/json/alloy/resource_3027029_v272125.json
+++ b/t/open311/endpoint/json/alloy/resource_3027029_v272125.json
@@ -1,0 +1,94 @@
+{
+  "colour": "#DF412C",
+  "geometry": {
+    "digiLength": null,
+    "lod16BboxIntMaxX": -210,
+    "lod16BboxIntMaxY": -11206,
+    "lod16BboxIntMinX": -210,
+    "lod16BboxIntMinY": -11207,
+    "featureGeom": {
+      "type": "Feature",
+      "id": "3027029",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -128047.3,
+            6852412.2
+          ],
+          [
+            -128014,
+            6852447.9
+          ]
+        ]
+      },
+      "properties": {},
+      "crs": {
+        "properties": {
+          "name": "EPSG:900913"
+        },
+        "type": "name"
+      }
+    }
+  },
+  "itemId": 3099981,
+  "resourceId": 3027029,
+  "sourceId": 2320,
+  "sourceTypeId": 1001181,
+  "title": "INS-00009033",
+  "values": [
+    {
+      "attributeId": 1003787,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_NUMBER",
+      "value": "INS-00009033"
+    },
+    {
+      "attributeId": 1001546,
+      "attributeCode": "GRP_PROJECT_TASK_ATT_PROJECT_TASK_STATUS",
+      "value": {
+        "parentReferenceContainerId": null,
+        "systemVersion": {
+          "allReferencesId": null,
+          "allResourcesId": null,
+          "childSummaryId": null
+        },
+        "values": [
+          {
+            "referenceId": 298204,
+            "resourceId": 2,
+            "sourceId": null
+          }
+        ]
+      }
+    },
+    {
+      "attributeId": 1001825,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_TEAM",
+      "value": {
+        "parentReferenceContainerId": null,
+        "systemVersion": {
+          "allReferencesId": null,
+          "allResourcesId": null,
+          "childSummaryId": null
+        },
+        "values": [
+          {
+            "referenceId": 291702,
+            "resourceId": 743500,
+            "sourceId": null
+          }
+        ]
+      }
+    }
+  ],
+  "version": {
+    "currentSystemVersionId": 271882,
+    "endDate": "9999-12-31T00:00:00.000Z",
+    "endSystemVersionId": null,
+    "resourceSystemVersionId": 271882,
+    "startDate": "2014-01-01T11:59:40Z",
+    "startSystemVersionId": 268108,
+    "usedDate": "2019-02-19T18:19:14.543Z",
+    "usedSystemVersionId": 271882
+  }
+}

--- a/t/open311/endpoint/json/alloy/resource_3027030_v271881.json
+++ b/t/open311/endpoint/json/alloy/resource_3027030_v271881.json
@@ -1,0 +1,99 @@
+{
+  "colour": "#DF412C",
+  "geometry": {
+    "digiLength": null,
+    "lod16BboxIntMaxX": -210,
+    "lod16BboxIntMaxY": -11206,
+    "lod16BboxIntMinX": -210,
+    "lod16BboxIntMinY": -11207,
+    "featureGeom": {
+      "type": "Feature",
+      "id": "3027029",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -128047.3,
+            6852412.2
+          ],
+          [
+            -128014,
+            6852447.9
+          ]
+        ]
+      },
+      "properties": {},
+      "crs": {
+        "properties": {
+          "name": "EPSG:900913"
+        },
+        "type": "name"
+      }
+    }
+  },
+  "itemId": 3099981,
+  "resourceId": 3027030,
+  "sourceId": 2320,
+  "sourceTypeId": 1001181,
+  "title": "INS-00009034",
+  "values": [
+    {
+      "attributeId": 1003787,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_NUMBER",
+      "value": "INS-00009034"
+    },
+    {
+      "attributeId": 1011096,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_-_ENQUIRY_-_REQUEST_FOR_SERVICE_RESPONSE_TO_CUSTOMER",
+      "value": "This is a customer response"
+    },
+    {
+      "attributeId": 1001546,
+      "attributeCode": "GRP_PROJECT_TASK_ATT_PROJECT_TASK_STATUS",
+      "value": {
+        "parentReferenceContainerId": null,
+        "systemVersion": {
+          "allReferencesId": null,
+          "allResourcesId": null,
+          "childSummaryId": null
+        },
+        "values": [
+          {
+            "referenceId": 298204,
+            "resourceId": 2,
+            "sourceId": null
+          }
+        ]
+      }
+    },
+    {
+      "attributeId": 1001825,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_TEAM",
+      "value": {
+        "parentReferenceContainerId": null,
+        "systemVersion": {
+          "allReferencesId": null,
+          "allResourcesId": null,
+          "childSummaryId": null
+        },
+        "values": [
+          {
+            "referenceId": 291702,
+            "resourceId": 743500,
+            "sourceId": null
+          }
+        ]
+      }
+    }
+  ],
+  "version": {
+    "currentSystemVersionId": 271881,
+    "endDate": "9999-12-31T00:00:00.000Z",
+    "endSystemVersionId": null,
+    "resourceSystemVersionId": 271883,
+    "startDate": "2014-01-01T11:59:40Z",
+    "startSystemVersionId": 268108,
+    "usedDate": "2019-02-19T18:19:14.543Z",
+    "usedSystemVersionId": 271883
+  }
+}

--- a/t/open311/endpoint/json/alloy/resource_versions_3027030.json
+++ b/t/open311/endpoint/json/alloy/resource_versions_3027030.json
@@ -1,0 +1,34 @@
+[{
+  "changeTypeCode": "CONTROLLED_CHANGE",
+  "comment": "Resource Edit Res Id: 271883",
+  "currentSystemVersionId": 271883,
+  "endDate": "9999-12-31T00:00:00.000Z",
+  "endSystemVersionId": null,
+  "startDate": "2014-01-01T11:59:40.140Z",
+  "startSystemVersionId": 272130,
+  "stateCode": "COMMITTED",
+  "timestamp": "2019-02-26T14:44:06.140Z",
+  "userId": 360
+}, {
+  "changeTypeCode": "CONTROLLED_CHANGE",
+  "comment": "Resource Edit Res Id: 4947668",
+  "currentSystemVersionId": 271881,
+  "endDate": "9999-12-31T00:00:00.000Z",
+  "endSystemVersionId": null,
+  "startDate": "2019-02-26T14:36:35.190Z",
+  "startSystemVersionId": 271129,
+  "stateCode": "COMMITTED",
+  "timestamp": "2019-02-26T14:36:35.190Z",
+  "userId": 360
+}, {
+  "changeTypeCode": "CONTROLLED_CHANGE",
+  "comment": "Resource Create: 4947668",
+  "currentSystemVersionId": 271070,
+  "endDate": "9999-12-31T00:00:00.000Z",
+  "endSystemVersionId": null,
+  "startDate": "2019-02-25T12:48:03.963Z",
+  "startSystemVersionId": 270125,
+  "stateCode": "COMMITTED",
+  "timestamp": "2019-02-25T12:48:03.963Z",
+  "userId": 491
+}]


### PR DESCRIPTION
In order to check if the customer comments has changed we need to fetch
the previous version and compare the two, and only if they are different
do we set the description. Otherwise once customer comments is set we'll
display an update on FMS for every change in Alloy.