### PR TITLE
Hounslow Confirm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - cp conf/general.yml-example conf/general.yml
   - cp conf/council-banes_confirm.yml-example conf/council-banes_confirm.yml
   - cp conf/council-buckinghamshire_confirm.yml-example conf/council-buckinghamshire_confirm.yml
+  - cp conf/council-hounslow_confirm.yml-example conf/council-hounslow_confirm.yml
   - cp conf/council-lincolnshire_confirm.yml-example conf/council-lincolnshire_confirm.yml
   - cp conf/council-northamptonshire_alloy.yml-example conf/council-northamptonshire_alloy.yml
   - 'if [ "$TRAVIS_PERL_VERSION" = "5.24" ]; then export HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,local/lib/perl5,^t"; fi'

--- a/bin/confirm-upload
+++ b/bin/confirm-upload
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+}
+
+use Open311::Endpoint::Integration::UK;
+
+my $uk = Open311::Endpoint::Integration::UK->new;
+
+$uk->confirm_upload;

--- a/conf/council-hounslow_confirm.yml-example
+++ b/conf/council-hounslow_confirm.yml-example
@@ -1,0 +1,11 @@
+{
+  "endpoint_url": "",
+  "username": "",
+  "password": "",
+  "tenant_id": "",
+  "server_timezone": "Europe/London",
+  "customer_type_code": "",
+  "point_of_contact_code": "",
+  "enquiry_method_code": "",
+  "service_whitelist": {},
+}

--- a/conf/crontab-example
+++ b/conf/crontab-example
@@ -1,0 +1,5 @@
+# Timed tasks for open311-adapter
+
+PATH=/usr/local/bin:/usr/bin:/bin
+
+*/5 * * * * run-with-lockfile -n "$BASE/confirm-upload.lock" "$BASE/bin/confirm-upload" || echo "stalled?"

--- a/perllib/Integrations/Alloy/Northamptonshire.pm
+++ b/perllib/Integrations/Alloy/Northamptonshire.pm
@@ -12,6 +12,7 @@ has config_filename => (
 
 sub _build_config_file {
     my $self = shift;
+    # uncoverable statement
     path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
 }
 

--- a/perllib/Integrations/Confirm/BANES.pm
+++ b/perllib/Integrations/Confirm/BANES.pm
@@ -12,6 +12,7 @@ has config_filename => (
 
 sub _build_config_file {
     my $self = shift;
+    # uncoverable statement
     path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
 }
 

--- a/perllib/Integrations/Confirm/Buckinghamshire.pm
+++ b/perllib/Integrations/Confirm/Buckinghamshire.pm
@@ -12,6 +12,7 @@ has config_filename => (
 
 sub _build_config_file {
     my $self = shift;
+    # uncoverable statement
     path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
 }
 

--- a/perllib/Integrations/Confirm/Hounslow.pm
+++ b/perllib/Integrations/Confirm/Hounslow.pm
@@ -12,6 +12,7 @@ has config_filename => (
 
 sub _build_config_file {
     my $self = shift;
+    # uncoverable statement
     path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
 }
 

--- a/perllib/Integrations/Confirm/Hounslow.pm
+++ b/perllib/Integrations/Confirm/Hounslow.pm
@@ -1,0 +1,18 @@
+package Integrations::Confirm::Hounslow;
+
+use Path::Tiny;
+use Moo;
+extends 'Integrations::Confirm';
+with 'Role::Config';
+
+has config_filename => (
+    is => 'ro',
+    default => 'hounslow_confirm',
+);
+
+sub _build_config_file {
+    my $self = shift;
+    path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
+}
+
+1;

--- a/perllib/Integrations/Confirm/Lincolnshire.pm
+++ b/perllib/Integrations/Confirm/Lincolnshire.pm
@@ -12,6 +12,7 @@ has config_filename => (
 
 sub _build_config_file {
     my $self = shift;
+    # uncoverable statement
     path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
 }
 

--- a/perllib/Integrations/WDM/Oxfordshire.pm
+++ b/perllib/Integrations/WDM/Oxfordshire.pm
@@ -12,6 +12,7 @@ has config_filename => (
 
 sub _build_config_file {
     my $self = shift;
+    # uncoverable statement
     path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
 }
 

--- a/perllib/Open311/Endpoint.pm
+++ b/perllib/Open311/Endpoint.pm
@@ -300,9 +300,13 @@ sub dispatch_request {
         $self->call_api( GET_Service_Definition => $service_id, $args );
     },
 
-    sub (POST + /requests + %:@media_url~&*) {
-        my ($self, $args) = @_;
-        $self->call_api( POST_Service_Request => $args );
+    sub (POST + /requests + %:@media_url~&* + **) {
+        my ($self, $args, $uploads) = @_;
+        my @files = grep {
+            $_->is_upload
+        } values %$uploads;
+        $args->{uploads} = \@files;
+        $self->call_api( POST_Service_Request => $args, );
     },
 
     sub (GET + /tokens/*) {
@@ -470,6 +474,7 @@ sub POST_Service_Request_input_schema {
                 phone => '//str',
                 description => '//str',
                 media_url => { type => '//arr', contents => '//str' },
+                uploads => { type => '//arr', contents => '//any' },
                 %{ $attributes{optional} || {}},
                 (map %$_, @address_options),
                 $self->get_jurisdiction_id_optional_clause,

--- a/perllib/Open311/Endpoint/Integration/UK/Hounslow.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Hounslow.pm
@@ -1,0 +1,19 @@
+package Open311::Endpoint::Integration::UK::Hounslow;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::Confirm';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'hounslow_confirm';
+    return $class->$orig(%args);
+};
+
+use Integrations::Confirm::Hounslow;
+
+has integration_class => (
+    is => 'ro',
+    default => 'Integrations::Confirm::Hounslow'
+);
+
+1;

--- a/perllib/Open311/Endpoint/Role/ConfigFile.pm
+++ b/perllib/Open311/Endpoint/Role/ConfigFile.pm
@@ -2,7 +2,7 @@ package Open311::Endpoint::Role::ConfigFile;
 use Moo::Role;
 use Path::Tiny 'path';
 use Carp 'croak';
-use YAML::XS qw(LoadFile);
+use YAML::XS qw(LoadFile Load);
 use Types::Standard qw( Maybe Str );
 
 has config_file => (
@@ -15,7 +15,10 @@ around BUILDARGS => sub {
     my $class = shift;
 
     my %args = @_;
-    if (my $config_file = $args{config_file}) {
+    if (my $config_data = $args{config_data}) {
+        my $config = Load($config_data) or croak "Couldn't load config from string";
+        return $class->$next(%$config, %args);
+    } elsif (my $config_file = $args{config_file}) {
         my $cfg = path($config_file);
         croak "$config_file is not a file" unless $cfg->is_file;
 

--- a/t/open311/endpoint/confirm_upload.t
+++ b/t/open311/endpoint/confirm_upload.t
@@ -1,0 +1,117 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::MockModule;
+use HTTP::Request::Common;
+use JSON::MaybeXS;
+use Path::Tiny;
+use Open311::Endpoint::Integration::UK;
+
+# Override config of the Integration package
+my $uploads_dir = Path::Tiny->tempdir;
+my $hounslow_integ = Test::MockModule->new('Integrations::Confirm::Hounslow');
+$hounslow_integ->mock(config => sub {
+    {
+        web_url => 'http://www.example.org/web',
+        uploads_dir => $uploads_dir,
+        tenant_id => 'dummy',
+        server_timezone => 'Europe/London',
+    }
+});
+
+# And need to override the endpoint config, bit fiddly
+package Open311::Endpoint::Integration::UK::Dummy;
+use Moo;
+extends 'Open311::Endpoint::Integration::Confirm';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'dummy';
+    $args{config_data} = '
+service_whitelist:
+  Flooding & Drainage:
+    ABC_DEF: Flooding
+';
+    return $class->$orig(%args);
+};
+has integration_class => (is => 'ro', default => 'Integrations::Confirm::Hounslow');
+sub jurisdiction_id { return 'dummy'; }
+
+package main;
+
+# Also need to override any hits to a server
+my $open311 = Test::MockModule->new('Integrations::Confirm');
+$open311->mock(perform_request => sub {
+    my ($self, $op) = @_; # Don't care about subsequent ops
+    $op = $$op;
+    if ($op->name && $op->name eq 'GetEnquiryLookups') {
+        return {
+            OperationResponse => { GetEnquiryLookupsResponse => { TypeOfService => [
+                { ServiceCode => 'ABC', ServiceName => 'Graffiti', EnquirySubject => [ { SubjectCode => "DEF" } ] },
+            ] } }
+        };
+    }
+    $op = $op->value;
+    if ($op->name eq 'NewEnquiry') {
+        return { OperationResponse => { NewEnquiryResponse => { Enquiry => { EnquiryNumber => 2001 } } } };
+    }
+    return {};
+});
+my $lwp = Test::MockModule->new('LWP::UserAgent');
+$lwp->mock(get => sub {
+    return HTTP::Response->new(200, 'OK', [], '123');
+});
+$lwp->mock(request => sub {
+    my ($ua, $req) = @_;
+    return HTTP::Response->new(200, 'OK', [], '{"access_token":"123"}') if $req->uri =~ /oauth\/token/;
+    # A file upload
+    my $data = decode_json($req->content);
+    is $data->{enquiryNumber}, 2001;
+    is scalar @{$data->{centralDocLinks}}, 3;
+    return HTTP::Response->new(200, 'OK', [], '{}') if $req->uri =~ /centralEnquiries/;
+});
+
+# Now the actual tests
+
+use Open311::Endpoint::Integration::UK::Dummy;
+
+my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
+
+subtest "POST OK with uploads" => sub {
+    my $a_file = path(__FILE__);
+    my $req = POST '/requests.json',
+        Content_Type => 'form-data',
+        Content => [
+            api_key => 'test',
+            service_code => 'ABC_DEF',
+            address_string => '22 Acacia Avenue',
+            first_name => 'Bob',
+            last_name => 'Mould',
+            description => "This is the details",
+            'attribute[easting]' => 100,
+            'attribute[northing]' => 100,
+            'attribute[fixmystreet_id]' => 1001,
+            'attribute[title]' => 'Title',
+            'attribute[description]' => 'This is the details',
+            'attribute[report_url]' => 'http://example.com/report/1001',
+            'media_url' => 'http://example.com/image/1',
+            'media_url' => 'http://example.com/image/2',
+            anything => [ $a_file ],
+        ];
+    my $res = $endpoint->run_test_request($req);
+    ok $res->is_success, 'valid request' or diag $res->content;
+
+    is_deeply decode_json($res->content), [ { "service_request_id" => 2001 } ], 'correct json returned';
+    my $data = decode_json($uploads_dir->child('2001.json')->slurp_utf8);
+    is_deeply $data->{media_url}, [ 'http://example.com/image/1', 'http://example.com/image/2' ];
+    is path($data->{uploads}->[0])->basename, $a_file->basename, 'Correct file name stored';
+    is $uploads_dir->child('2001', $a_file->basename)->exists, 1, 'Uploaded file copied to right place';
+};
+
+subtest 'And test the uploading' => sub {
+    my $uk = Open311::Endpoint::Integration::UK->new;
+    $uk->confirm_upload;
+    # Tests are in the LWP UA mock above
+};
+
+done_testing;


### PR DESCRIPTION
WIP Confirm integration for Hounslow.

New features:

- Allow files to be uploaded directly to Confirm instead of just linking to FMS
- Services can be marked as private using Open311 keywords