### PR TITLE
[Bexley] Fetch more than one CSV file.

### DIFF
--- a/conf/council-bexley.yml-example
+++ b/conf/council-bexley.yml-example
@@ -1,6 +1,8 @@
 endpoint_url: ''
 username: FMS
-update_url: https://...
+update_urls:
+  - https://...
+  - https://...
 
 # For each category:
 #   name: The display name for the category

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -126,6 +126,7 @@ $bexley_end->mock(endpoint_config => sub {
 $bexley_end->mock(_get_csvs => sub {
     [ \<<EOF,
 "History Date/Time","Recorded Date","CRNo","Stage Desc.","Date Cleared","Inspection","LCA","Action Due","Event Type","Stage"
+13/03/2017 07:31,12/03/2019,569810,RECORDED,,NI1,N1,NI1MOB,Ignored,1
 13/03/2019 07:31,12/03/2019,569810,RECORDED,,NI1,N1,NI1MOB,,1
 14/03/2019 07:32,13/03/2019,569924,CLEARED,14/03/2019,NI2,NI2MOB,,,9
 17/04/2019 12:05,04/04/2019,560065,RECORDED,,SI6,S6,S6,,1

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -123,21 +123,36 @@ $bexley_end->mock(endpoint_config => sub {
         },
     }
 });
-$bexley_end->mock(_get_csv => sub {
-    \<<EOF;
-date_history,date_recorded,crno,request_type,stage_desc,date_cleared,inspection,lca,action_due,event_type,stage
-13/03/2019 07:31,12/03/2019,569810,HW,RECORDED,,NI1,N1,NI1MOB,,1
-14/03/2019 07:32,13/03/2019,569924,HW,CLEARED,14/03/2019,NI2,NI2MOB,,,9
-17/04/2019 12:05,04/04/2019,560065,HW,RECORDED,,SI6,S6,SI6MOB,,1
-17/04/2019 12:05,04/04/2019,560064,HW,RECORDED,,SI6,PTC,PTC,,1
-17/04/2019 12:32,02/04/2019,560057,HW,RECORDED,,NI3,NI3MOB,PTS,,1
-17/04/2019 13:29,04/04/2019,560063,HW,RECORDED,,SI6,S5,NCR,,1
-17/04/2019 13:34,02/04/2019,560056,HW,RECORDED,,SI6,SI6MOB,SI6MOB,,1
-17/04/2019 13:49,17/04/2019,560067,HW,RECORDED,,SI4,S4,SI4MOB,,1
-17/04/2019 13:50,04/04/2019,560058,HW,RECORDED,,SI6,SI6MOB,IR,,1
-17/04/2019 14:08,04/04/2019,560062,HW,RECORDED,,SI5,NCR,NCR,,1
+$bexley_end->mock(_get_csvs => sub {
+    [ \<<EOF,
+"History Date/Time","Recorded Date","CRNo","Stage Desc.","Date Cleared","Inspection","LCA","Action Due","Event Type","Stage"
+13/03/2019 07:31,12/03/2019,569810,RECORDED,,NI1,N1,NI1MOB,,1
+14/03/2019 07:32,13/03/2019,569924,CLEARED,14/03/2019,NI2,NI2MOB,,,9
+17/04/2019 12:05,04/04/2019,560065,RECORDED,,SI6,S6,SI6MOB,,1
+17/04/2019 12:05,04/04/2019,560064,RECORDED,,SI6,PTC,PTC,,1
+17/04/2019 12:32,02/04/2019,560057,RECORDED,,NI3,NI3MOB,PTS,,1
+17/04/2019 13:29,04/04/2019,560063,RECORDED,,SI6,S5,NCR,,1
+17/04/2019 13:34,02/04/2019,560056,RECORDED,,SI6,SI6MOB,SI6MOB,,1
+17/04/2019 13:49,17/04/2019,560067,RECORDED,,SI4,S4,SI4MOB,,1
+17/04/2019 13:50,04/04/2019,560058,RECORDED,,SI6,SI6MOB,IR,,1
+17/04/2019 14:08,04/04/2019,560062,RECORDED,,SI5,NCR,NCR,,1
 EOF
-});
+    \<<EOF
+"History Date/Time","Recorded Date","CRNo","Stage Desc.","Date Cleared","Maint. Stage","L.A.Code"
+24/09/2018 15:19,24/09/2018,2830,PROV.CLEAR,,CLAIMED,555830
+24/09/2018 20:34,24/09/2018,2832,PROV.CLEAR,,APPROVED,555831
+25/09/2018 08:34,25/09/2018,2833,PROV.CLEAR,,CLAIMED,555832
+25/09/2018 10:54,25/09/2018,2834,PROV.CLEAR,,CLAIMED,555837
+25/09/2018 14:51,25/09/2018,2835,MAINT,,COMMENCED,555840
+28/09/2018 09:21,28/09/2018,2845,MAINT,,ALLOCATED,555855
+01/10/2018 11:10,01/10/2018,2851,MAINT,,ALLOCATED,555861
+01/10/2018 14:55,01/10/2018,2853,PROV.CLEAR,,COMPLETED,555862
+02/10/2018 09:05,02/10/2018,2855,MAINT,,ORDERED,555863
+04/04/2019 08:28,04/04/2019,2857,MAINT,,ALLOCATED,555864
+02/05/2019 15:18,02/05/2019,2858,MAINT,,ORDERED,555865
+02/05/2019 17:03,02/05/2019,2860,MAINT,,ORDERED,555866
+EOF
+] });
 
 use Open311::Endpoint::Integration::UK::Bexley;
 
@@ -373,7 +388,7 @@ subtest "POST update OK" => sub {
 
 subtest "GET updates OK" => sub {
     my $res = $endpoint->run_test_request(
-        GET => '/servicerequestupdates.json?start_date=2019-01-01T00:00:00Z&end_date=2020-01-01T00:00:00Z',
+        GET => '/servicerequestupdates.json?start_date=2018-01-01T00:00:00Z&end_date=2020-01-01T00:00:00Z',
     );
     ok $res->is_success, 'valid request'
         or diag $res->content;
@@ -381,7 +396,7 @@ subtest "GET updates OK" => sub {
     is_deeply decode_json($res->content),
         [
            {
-              "update_id" => "569810_305b9fab",
+              "update_id" => "569810_50a9e498",
               "updated_datetime" => "2019-03-13T07:31:00+00:00",
               "service_request_id" => "569810",
               "status" => "investigating",
@@ -389,7 +404,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "569924_cc072b95",
+              "update_id" => "569924_1a1bb34a",
               "updated_datetime" => "2019-03-14T07:32:00+00:00",
               "service_request_id" => "569924",
               "status" => "fixed",
@@ -397,7 +412,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560065_8b6f97c5",
+              "update_id" => "560065_bad85ba1",
               "updated_datetime" => "2019-04-17T12:05:00+01:00",
               "service_request_id" => "560065",
               "status" => "investigating",
@@ -405,7 +420,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560064_b7e2d1f1",
+              "update_id" => "560064_13eebdf4",
               "updated_datetime" => "2019-04-17T12:05:00+01:00",
               "service_request_id" => "560064",
               "status" => "action_scheduled",
@@ -413,7 +428,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560057_04da2aa5",
+              "update_id" => "560057_9d1bacb4",
               "updated_datetime" => "2019-04-17T12:32:00+01:00",
               "service_request_id" => "560057",
               "status" => "action_scheduled",
@@ -421,7 +436,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560063_191d076c",
+              "update_id" => "560063_cb783d63",
               "updated_datetime" => "2019-04-17T13:29:00+01:00",
               "service_request_id" => "560063",
               "status" => "not_councils_responsibility",
@@ -429,7 +444,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560056_7481316d",
+              "update_id" => "560056_caf47a7e",
               "updated_datetime" => "2019-04-17T13:34:00+01:00",
               "service_request_id" => "560056",
               "status" => "investigating",
@@ -437,7 +452,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560067_c94b4dc5",
+              "update_id" => "560067_f9691c4d",
               "updated_datetime" => "2019-04-17T13:49:00+01:00",
               "service_request_id" => "560067",
               "status" => "investigating",
@@ -445,7 +460,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560058_1d1cbda6",
+              "update_id" => "560058_4b55f60b",
               "updated_datetime" => "2019-04-17T13:50:00+01:00",
               "service_request_id" => "560058",
               "status" => "internal_referral",
@@ -453,13 +468,109 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560062_761c376c",
+              "update_id" => "560062_a3923be9",
               "updated_datetime" => "2019-04-17T14:08:00+01:00",
               "service_request_id" => "560062",
               "status" => "not_councils_responsibility",
               "description" => "",
               "media_url" => "",
-           }
+           },
+           {
+              "update_id" => "2830_64d46557",
+              "updated_datetime" => "2018-09-24T15:19:00+01:00",
+              "service_request_id" => "2830",
+              "status" => "fixed",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2832_a9392c65",
+              "updated_datetime" => "2018-09-24T20:34:00+01:00",
+              "service_request_id" => "2832",
+              "status" => "fixed",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2833_9afcd333",
+              "updated_datetime" => "2018-09-25T08:34:00+01:00",
+              "service_request_id" => "2833",
+              "status" => "fixed",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2834_46771ac5",
+              "updated_datetime" => "2018-09-25T10:54:00+01:00",
+              "service_request_id" => "2834",
+              "status" => "fixed",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2835_5e4fc30c",
+              "updated_datetime" => "2018-09-25T14:51:00+01:00",
+              "service_request_id" => "2835",
+              "status" => "action_scheduled",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2845_31afb3ae",
+              "updated_datetime" => "2018-09-28T09:21:00+01:00",
+              "service_request_id" => "2845",
+              "status" => "action_scheduled",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2851_96a57964",
+              "updated_datetime" => "2018-10-01T11:10:00+01:00",
+              "service_request_id" => "2851",
+              "status" => "action_scheduled",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2853_1b06136b",
+              "updated_datetime" => "2018-10-01T14:55:00+01:00",
+              "service_request_id" => "2853",
+              "status" => "fixed",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2855_29558db7",
+              "updated_datetime" => "2018-10-02T09:05:00+01:00",
+              "service_request_id" => "2855",
+              "status" => "investigating",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2857_d3b60574",
+              "updated_datetime" => "2019-04-04T08:28:00+01:00",
+              "service_request_id" => "2857",
+              "status" => "action_scheduled",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2858_d0ce15e1",
+              "updated_datetime" => "2019-05-02T15:18:00+01:00",
+              "service_request_id" => "2858",
+              "status" => "investigating",
+              "description" => "",
+              "media_url" => "",
+           },
+           {
+              "update_id" => "2860_ebcd5547",
+              "updated_datetime" => "2019-05-02T17:03:00+01:00",
+              "service_request_id" => "2860",
+              "status" => "investigating",
+              "description" => "",
+              "media_url" => "",
+           },
        ], 'correct json returned';
 };
 

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -128,14 +128,14 @@ $bexley_end->mock(_get_csvs => sub {
 "History Date/Time","Recorded Date","CRNo","Stage Desc.","Date Cleared","Inspection","LCA","Action Due","Event Type","Stage"
 13/03/2019 07:31,12/03/2019,569810,RECORDED,,NI1,N1,NI1MOB,,1
 14/03/2019 07:32,13/03/2019,569924,CLEARED,14/03/2019,NI2,NI2MOB,,,9
-17/04/2019 12:05,04/04/2019,560065,RECORDED,,SI6,S6,SI6MOB,,1
+17/04/2019 12:05,04/04/2019,560065,RECORDED,,SI6,S6,S6,,1
 17/04/2019 12:05,04/04/2019,560064,RECORDED,,SI6,PTC,PTC,,1
 17/04/2019 12:32,02/04/2019,560057,RECORDED,,NI3,NI3MOB,PTS,,1
 17/04/2019 13:29,04/04/2019,560063,RECORDED,,SI6,S5,NCR,,1
 17/04/2019 13:34,02/04/2019,560056,RECORDED,,SI6,SI6MOB,SI6MOB,,1
-17/04/2019 13:49,17/04/2019,560067,RECORDED,,SI4,S4,SI4MOB,,1
+17/04/2019 13:49,17/04/2019,560067,RECORDED,,SI4,S4,CLEARREQ,,1
 17/04/2019 13:50,04/04/2019,560058,RECORDED,,SI6,SI6MOB,IR,,1
-17/04/2019 14:08,04/04/2019,560062,RECORDED,,SI5,NCR,NCR,,1
+17/04/2019 14:08,04/04/2019,560062,RECORDED,,SI5,NCR,CR,,1
 EOF
     \<<EOF
 "History Date/Time","Recorded Date","CRNo","Stage Desc.","Date Cleared","Maint. Stage","L.A.Code"
@@ -412,10 +412,10 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560065_bad85ba1",
+              "update_id" => "560065_128faf5f",
               "updated_datetime" => "2019-04-17T12:05:00+01:00",
               "service_request_id" => "560065",
-              "status" => "investigating",
+              "status" => "in_progress",
               "description" => "",
               "media_url" => "",
            },
@@ -452,10 +452,10 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560067_f9691c4d",
+              "update_id" => "560067_24e7b980",
               "updated_datetime" => "2019-04-17T13:49:00+01:00",
               "service_request_id" => "560067",
-              "status" => "investigating",
+              "status" => "no_further_action",
               "description" => "",
               "media_url" => "",
            },
@@ -468,10 +468,10 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560062_a3923be9",
+              "update_id" => "560062_94e427db",
               "updated_datetime" => "2019-04-17T14:08:00+01:00",
               "service_request_id" => "560062",
-              "status" => "not_councils_responsibility",
+              "status" => "fixed",
               "description" => "",
               "media_url" => "",
            },


### PR DESCRIPTION
Bexley updates will be coming from 2 CSVs, not one. This adjusts the code to read both, work out automatically the headers rather than bind fixed ones, etc.
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1366