### PR TITLE
Do not die on failure if record created.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/Symology.pm
@@ -190,7 +190,7 @@ sub post_service_request {
         @args
     );
 
-    $self->check_error($response, 'Request');
+    $self->check_error($response, 'SendRequest');
 
     my $result = $response->{SendRequestResults}->{SendRequestResultRow};
     my $request = $self->new_request(
@@ -233,7 +233,7 @@ sub post_service_request_update {
         @args
     );
 
-    $self->check_error($response, 'Action');
+    $self->check_error($response, 'SendEventAction');
 
     return Open311::Endpoint::Service::Request::Update::mySociety->new(
         status => lc $args->{status},
@@ -248,15 +248,24 @@ sub check_error {
 
     $self->logger->debug(encode_json($response));
 
-    unless (($response->{StatusCode}//-1) == 0) {
-        my $error = "Couldn't create $type in Symology: $response->{StatusMessage}";
-        my $result = $response->{SendRequestResults}->{SendRequestResultRow};
-        $result = [ $result ] if ref $result ne 'ARRAY';
-        foreach (@$result) {
-            $error .= " - $_->{MessageText}" if $_->{RecordType} == 1;
-            $error .= " - created request $_->{ConvertCRNo}" if $_->{RecordType} == 2;
+    # StatusCode is 0 on success, but we can get failures and still create an
+    # entry, in which case there is no point trying again, so look for creation.
+    my $crno;
+    my $error = $response->{StatusMessage};
+    my $result = $response->{$type."Results"}->{$type."ResultRow"};
+    $result = [ $result ] if ref $result ne 'ARRAY';
+    foreach (@$result) {
+        $error .= " - $_->{MessageText}" if $_->{RecordType} == 1;
+        if ($_->{RecordType} == 2 && $type eq 'SendRequest') {
+            $crno = $_->{ConvertCRNo};
+            $error .= " - created request $crno";
         }
-        $self->log_and_die($error);
+    }
+
+    if (($response->{StatusCode}//-1) == 0 || $crno) {
+        $self->logger->debug("Created $type in Symology: $error");
+    } else {
+        $self->log_and_die("Couldn't create $type in Symology: $error");
     }
 }
 

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -65,8 +65,10 @@ $soap_lite->mock(call => sub {
         }
         return {
             StatusCode => 0,
+            StatusMessage => 'Success',
             SendRequestResults => {
                 SendRequestResultRow => {
+                    RecordType => 2,
                     ConvertCRNo => 1001,
                 }
             }
@@ -77,8 +79,10 @@ $soap_lite->mock(call => sub {
         is_deeply \@request, [ 'ServiceCode', 1001, 123, 'CCA', '', 'FMS', "This is the update$photo_desc" ];
         return {
             StatusCode => 0,
+            StatusMessage => 'Event Loaded',
             SendEventActionResults => {
                 SendEventActionResultRow => {
+                    RecordType => 2,
                 }
             }
         };
@@ -304,7 +308,7 @@ subtest "POST Abandoned Vehicles Bad" => sub {
 
     is_deeply decode_json($res->content),
         [ {
-            "description" => "Couldn't create Request in Symology: Failed - Unknown identifier\n",
+            "description" => "Couldn't create SendRequest in Symology: Failed - Unknown identifier\n",
             "code" => 500,
         } ], 'correct json returned';
 };


### PR DESCRIPTION
Sometimes Bexley give a warning but still create the record. They don't allow resubmission of a created record, so in that case we should tell FMS that the report has been sent.