### PR TITLE
[Confirm] allow categories to exist in multiple groups

### DIFF
--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -129,7 +129,7 @@ subtest "GET Service List" => sub {
 <services>
   <service>
     <description>Flooding</description>
-    <group>Flooding &amp; Drainage</group>
+    <group>Flooding,&quot;Flooding &amp; Drainage&quot;</group>
     <keywords></keywords>
     <metadata>true</metadata>
     <service_code>ABC_DEF</service_code>
@@ -395,7 +395,7 @@ subtest "GET Service List - private services" => sub {
 <services>
   <service>
     <description>Flooding</description>
-    <group>Flooding &amp; Drainage</group>
+    <group>&quot;Flooding &amp; Drainage&quot;</group>
     <keywords>private</keywords>
     <metadata>true</metadata>
     <service_code>ABC_DEF</service_code>

--- a/t/open311/endpoint/confirm.yml
+++ b/t/open311/endpoint/confirm.yml
@@ -7,6 +7,8 @@ default_site_code: 999999
 service_whitelist:
   Flooding & Drainage:
     ABC_DEF: Flooding
+  Flooding:
+    ABC_DEF: Flooding
 reverse_status_mapping:
   DUP: duplicate
   INP: in_progress


### PR DESCRIPTION
Allow categories to be under more than one group in the whitelist. Only
one services entry per category is generated but it will include all the
groups in the group tag.