### PR TITLE
[Confirm] Don’t output reports with 0/0 easting/northing

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -45,3 +45,4 @@ requires 'Test::LongString';
 requires 'Test::MockModule';
 requires 'Test::MockTime';
 requires 'Test::More';
+requires 'Test::Output';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -62,6 +62,21 @@ DISTRIBUTIONS
       Storable 0
       String::CRC32 0
       Time::HiRes 0
+  Capture-Tiny-0.48
+    pathname: D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz
+    provides:
+      Capture::Tiny 0.48
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      File::Spec 0
+      File::Temp 0
+      IO::Handle 0
+      Scalar::Util 0
+      perl 5.006
+      strict 0
+      warnings 0
   Class-Data-Inheritable-0.08
     pathname: T/TM/TMTM/Class-Data-Inheritable-0.08.tar.gz
     provides:
@@ -2494,6 +2509,16 @@ DISTRIBUTIONS
       Test::More 0
       Time::Local 0
       Time::Piece 1.08
+  Test-Output-1.031
+    pathname: B/BD/BDFOY/Test-Output-1.031.tar.gz
+    provides:
+      Test::Output 1.031
+    requirements:
+      Capture::Tiny 0.17
+      ExtUtils::MakeMaker 6.64
+      File::Spec::Functions 0
+      File::Temp 0.17
+      perl 5.008
   Test-Requires-0.10
     pathname: T/TO/TOKUHIROM/Test-Requires-0.10.tar.gz
     provides:

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -598,7 +598,7 @@ sub get_service_requests {
             $status = 'open';
         }
 
-        unless (defined $enquiry->{EnquiryY} && defined $enquiry->{EnquiryX}) {
+        unless ($enquiry->{EnquiryY} && $enquiry->{EnquiryX}) {
             warn "no easting/northing for Enquiry $enquiry->{EnquiryNumber}\n";
             next;
         }


### PR DESCRIPTION
When fetching reports from Confirm to display on FMS we don't want to include those which don't have a location. Previously open311-adapter didn't include in the `GET /requests.xml` output any Enquiries that didn't have an `EnquiryX` & `EnquiryY` defined. However some Confirm instances set those values to `0` which meant they were being passed through to FMS.