### PR TITLE
[Northamptonshire] always set external_status_code on defect updates

### DIFF
--- a/t/open311/endpoint/alloy.t
+++ b/t/open311/endpoint/alloy.t
@@ -128,10 +128,14 @@ $integration->mock('api_call', sub {
             $content = path(__FILE__)->sibling('json/alloy/resource_versions_4947502.json')->slurp;
         } elsif ( $call eq 'resource/3027030/versions' ) {
             $content = path(__FILE__)->sibling('json/alloy/resource_versions_3027030.json')->slurp;
+        } elsif ( $call eq 'resource/3027031/versions' ) {
+            $content = path(__FILE__)->sibling('json/alloy/resource_versions_3027031.json')->slurp;
         } elsif ( $call eq 'resource/3027029/full?systemVersion=272125' ) {
             $content = path(__FILE__)->sibling('json/alloy/resource_3027029_v272125.json')->slurp;
         } elsif ( $call eq 'resource/3027030/full?systemVersion=271881' ) {
             $content = path(__FILE__)->sibling('json/alloy/resource_3027030_v271881.json')->slurp;
+        } elsif ( $call eq 'resource/3027031/full?systemVersion=271883' ) {
+            $content = path(__FILE__)->sibling('json/alloy/resource_3027031_v271883.json')->slurp;
         } elsif ( $call eq 'resource/1' ) {
             $content = '{ "sourceTypeId": 800 }';
         } elsif ( $call eq 'source-type/800/linked-source-types' ) {
@@ -331,7 +335,16 @@ subtest "check fetch updates" => sub {
         media_url => '',
     },
     {
-        status => 'action_scheduled',
+        status => 'not_councils_responsibility',
+        service_request_id => '3027031',
+        description => '',
+        updated_datetime => '2019-02-19T02:42:40Z',
+        update_id => '271884',
+        media_url => '',
+        external_status_code => 4281525,
+    },
+    {
+        status => 'fixed',
         service_request_id => '4947502',
         description => '',
         updated_datetime => '2019-02-19T09:11:08Z',
@@ -369,6 +382,15 @@ subtest "check fetch multiple updates" => sub {
         media_url => '',
     },
     {
+        status => 'not_councils_responsibility',
+        service_request_id => '3027031',
+        description => '',
+        updated_datetime => '2019-02-19T02:42:40Z',
+        update_id => '271884',
+        media_url => '',
+        external_status_code => 4281525,
+    },
+    {
         status => 'action_scheduled',
         service_request_id => '4947502',
         description => '',
@@ -376,6 +398,7 @@ subtest "check fetch multiple updates" => sub {
         update_id => '271877',
         media_url => '',
         fixmystreet_id => '10034',
+        external_status_code => 4281523,
     },
     {
         status => 'action_scheduled',
@@ -384,6 +407,7 @@ subtest "check fetch multiple updates" => sub {
         updated_datetime => '2019-01-03T09:11:08Z',
         update_id => '271884',
         media_url => '',
+        external_status_code => 4281523,
     },
 ], 'correct json returned';
 };

--- a/t/open311/endpoint/alloy.yml
+++ b/t/open311/endpoint/alloy.yml
@@ -150,7 +150,7 @@
   },
 
   "inspection_closure_mapping": {
-    4281523: 'in_progress', # works instructed
+    4281523: 'action_scheduled', # works instructed
     4281524: 'no_further_action', # no action necessary
     4281525: 'not_councils_responsibility', # outside NCC control
     4281526: 'no_further_action', # highways to monitor

--- a/t/open311/endpoint/json/alloy/defect_search.json
+++ b/t/open311/endpoint/json/alloy/defect_search.json
@@ -113,7 +113,7 @@
         {
           "attributeId": 1000604,
           "attributeCode": "GRP_DEFECT_STANDARD_ATT_DEFECT_STATUS",
-          "value": 1001025
+          "value": 1001026
         },
         {
           "attributeId": 1003788,

--- a/t/open311/endpoint/json/alloy/inspect_search.json
+++ b/t/open311/endpoint/json/alloy/inspect_search.json
@@ -201,6 +201,124 @@
         "usedDate": "2019-02-19T18:19:14.543Z",
         "usedSystemVersionId": 271883
       }
+    },
+    {
+      "colour": "#DF412C",
+      "geometry": {
+        "digiLength": null,
+        "lod16BboxIntMaxX": -210,
+        "lod16BboxIntMaxY": -11206,
+        "lod16BboxIntMinX": -210,
+        "lod16BboxIntMinY": -11207,
+        "featureGeom": {
+          "type": "Feature",
+          "id": "3027029",
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [
+              [
+                -128047.3,
+                6852412.2
+              ],
+              [
+                -128014,
+                6852447.9
+              ]
+            ]
+          },
+          "properties": {},
+          "crs": {
+            "properties": {
+              "name": "EPSG:900913"
+            },
+            "type": "name"
+          }
+        }
+      },
+      "itemId": 3099982,
+      "resourceId": 3027031,
+      "sourceId": 2320,
+      "sourceTypeId": 1001181,
+      "title": "INS-00009035",
+      "values": [
+        {
+          "attributeId": 1003787,
+          "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_NUMBER",
+          "value": "INS-00009035"
+        },
+        {
+          "attributeId": 1011096,
+          "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_-_ENQUIRY_-_REQUEST_FOR_SERVICE_RESPONSE_TO_CUSTOMER",
+          "value": ""
+        },
+        {
+          "attributeId": 1001546,
+          "attributeCode": "GRP_PROJECT_TASK_ATT_PROJECT_TASK_STATUS",
+          "value": {
+            "parentReferenceContainerId": null,
+            "systemVersion": {
+              "allReferencesId": null,
+              "allResourcesId": null,
+              "childSummaryId": null
+            },
+            "values": [
+              {
+                "referenceId": 298204,
+                "resourceId": 6,
+                "sourceId": null
+              }
+            ]
+          }
+        },
+        {
+          "attributeId": 1010926,
+          "attributeCode": "STU_INSPECTION_ST_USER_INSPECTION_-_ENQUIRY_-_REQUEST_FOR_SERVICE_ATT_REASON_FOR_CLOSURE",
+          "value": {
+            "parentReferenceContainerId": null,
+            "systemVersion": {
+              "allReferencesId": null,
+              "allResourcesId": null,
+              "childSummaryId": null
+            },
+            "values": [
+              {
+                "referenceId": 3598667,
+                "resourceId": 4281525,
+                "sourceId": null
+              }
+            ]
+          }
+        },
+        {
+          "attributeId": 1001825,
+          "attributeCode": "GRP_INSPECTION_STANDARD_ATT_TEAM",
+          "value": {
+            "parentReferenceContainerId": null,
+            "systemVersion": {
+              "allReferencesId": null,
+              "allResourcesId": null,
+              "childSummaryId": null
+            },
+            "values": [
+              {
+                "referenceId": 291702,
+                "resourceId": 743500,
+                "sourceId": null
+              }
+            ]
+          }
+        }
+      ],
+      "version": {
+        "currentSystemVersionId": 271884,
+        "endDate": "9999-12-31T00:00:00.000Z",
+        "endSystemVersionId": null,
+        "resourceSystemVersionId": 271884,
+        "startDate": "2019-02-19T02:42:40Z",
+        "startSystemVersionId": 268108,
+        "usedDate": "2019-02-19T18:19:14.543Z",
+        "usedSystemVersionId": 271884
+      }
     }
   ]
 }

--- a/t/open311/endpoint/json/alloy/resource_3027031_v271883.json
+++ b/t/open311/endpoint/json/alloy/resource_3027031_v271883.json
@@ -1,0 +1,118 @@
+{
+  "colour": "#DF412C",
+  "geometry": {
+    "digiLength": null,
+    "lod16BboxIntMaxX": -210,
+    "lod16BboxIntMaxY": -11206,
+    "lod16BboxIntMinX": -210,
+    "lod16BboxIntMinY": -11207,
+    "featureGeom": {
+      "type": "Feature",
+      "id": "3027029",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -128047.3,
+            6852412.2
+          ],
+          [
+            -128014,
+            6852447.9
+          ]
+        ]
+      },
+      "properties": {},
+      "crs": {
+        "properties": {
+          "name": "EPSG:900913"
+        },
+        "type": "name"
+      }
+    }
+  },
+  "itemId": 3099982,
+  "resourceId": 3027031,
+  "sourceId": 2320,
+  "sourceTypeId": 1001181,
+  "title": "INS-00009035",
+  "values": [
+    {
+      "attributeId": 1003787,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_NUMBER",
+      "value": "INS-00009035"
+    },
+    {
+      "attributeId": 1011096,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_INSPECTION_-_ENQUIRY_-_REQUEST_FOR_SERVICE_RESPONSE_TO_CUSTOMER",
+      "value": ""
+    },
+    {
+      "attributeId": 1001546,
+      "attributeCode": "GRP_PROJECT_TASK_ATT_PROJECT_TASK_STATUS",
+      "value": {
+        "parentReferenceContainerId": null,
+        "systemVersion": {
+          "allReferencesId": null,
+          "allResourcesId": null,
+          "childSummaryId": null
+        },
+        "values": [
+          {
+            "referenceId": 298204,
+            "resourceId": 4,
+            "sourceId": null
+          }
+        ]
+      }
+    },
+    {
+      "attributeId": 1010926,
+      "attributeCode": "STU_INSPECTION_ST_USER_INSPECTION_-_ENQUIRY_-_REQUEST_FOR_SERVICE_ATT_REASON_FOR_CLOSURE",
+      "value": {
+        "parentReferenceContainerId": null,
+        "systemVersion": {
+          "allReferencesId": null,
+          "allResourcesId": null,
+          "childSummaryId": null
+        },
+        "values": [
+          {
+            "referenceId": 3598667,
+            "resourceId": 4281525,
+            "sourceId": null
+          }
+        ]
+      }
+    },
+    {
+      "attributeId": 1001825,
+      "attributeCode": "GRP_INSPECTION_STANDARD_ATT_TEAM",
+      "value": {
+        "parentReferenceContainerId": null,
+        "systemVersion": {
+          "allReferencesId": null,
+          "allResourcesId": null,
+          "childSummaryId": null
+        },
+        "values": [
+          {
+            "referenceId": 291702,
+            "resourceId": 743500,
+            "sourceId": null
+          }
+        ]
+      }
+    }
+  ],
+  "version": {
+    "currentSystemVersionId": 271884,
+    "endDate": "9999-12-31T00:00:00.000Z",
+    "endSystemVersionId": null,
+    "resourceSystemVersionId": 271884,
+    "startDate": "2019-01-01T01:42:40Z",
+    "startSystemVersionId": 268108,
+    "usedDate": "2019-02-19T18:19:14.543Z",
+    "usedSystemVersionId": 271884
+  }
+}

--- a/t/open311/endpoint/json/alloy/resource_versions_3027031.json
+++ b/t/open311/endpoint/json/alloy/resource_versions_3027031.json
@@ -1,0 +1,12 @@
+[{
+  "changeTypeCode": "CONTROLLED_CHANGE",
+  "comment": "Resource Edit Res Id: 271883",
+  "currentSystemVersionId": 271883,
+  "endDate": "9999-12-31T00:00:00.000Z",
+  "endSystemVersionId": null,
+  "startDate": "2014-01-01T11:59:40.140Z",
+  "startSystemVersionId": 272130,
+  "stateCode": "COMMITTED",
+  "timestamp": "2019-02-26T14:44:06.140Z",
+  "userId": 360
+}]


### PR DESCRIPTION
We need to set this to stop phantom updates being produced. This
happens because when an inspection is closed it always sets an
external_status_code which we never unset. Then when updates arrive
from defects with no external_status_code the template fetching code at
FixMyStreet sees that the external_status_code has changed and fetches
the template. This means we always get an update even if nothing has
changed. So, set the external_status_code on defects associated with an
inspection to the external_status_code used when an inspection is marked
for raising as a defect.