### PR TITLE
Add new <groups> output for multiple groups.

### DIFF
--- a/perllib/Open311/Endpoint.pm
+++ b/perllib/Open311/Endpoint.pm
@@ -348,8 +348,9 @@ sub GET_Service_List {
         {
             keywords => (join ',' => @{ $service->keywords } ),
             metadata => $self->format_boolean( $service->has_attributes ),
+            @{$service->groups} ? (groups => $service->groups) : (group => $service->group),
             map { $_ => $service->$_ } 
-                qw/ service_name service_code description type group /,
+                qw/ service_name service_code description type /,
         }
     } $self->services($args);
     return {

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -13,7 +13,6 @@ use Open311::Endpoint::Service::Request::CanBeNonPublic;
 
 use Path::Tiny;
 use SOAP::Lite; # +trace => [ qw/method debug/ ];
-use Text::CSV;
 
 
 around BUILDARGS => sub {
@@ -523,7 +522,6 @@ sub _services {
         }
     }
 
-    my $csv = Text::CSV->new();
     my @services = ();
     my %service_codes;
     for my $group (sort keys %{ $self->service_whitelist }) {
@@ -536,13 +534,13 @@ sub _services {
             }
             my $name = $whitelist->{$code} eq 1 ? $subject->{SubjectName} :  $whitelist->{$code};
             if ( defined $service_codes{ $code } ) {
-                push @{$service_codes{$code}->{group}}, $group;
+                push @{$service_codes{$code}->{groups}}, $group;
             } else {
                 $service_codes{$code} = {
                     service_name => $name,
                     service_code => $code,
                     description => $name,
-                    group => [$group],
+                    groups => [$group],
                     keywords => $private_services{$code} ? [qw/ private /] : [],
                 };
             }
@@ -550,8 +548,6 @@ sub _services {
     }
     for my $code (sort keys %service_codes) {
         my %service = %{ $service_codes{$code} };
-        $csv->combine(@{$service{group}});
-        $service{group} = $csv->string;
         my $o311_service = $self->service_class->new(%service);
         for (@{$services{$code}->{attribs}}) {
             push @{$o311_service->attributes}, $_;

--- a/perllib/Open311/Endpoint/Schema.pm
+++ b/perllib/Open311/Endpoint/Schema.pm
@@ -96,6 +96,10 @@ has schema => (
                 optional => {
                     keywords => '//str',
                     group => '//str',
+                    groups => {
+                        type => '//arr',
+                        contents => '//str',
+                    }
                 }
             }
         );

--- a/perllib/Open311/Endpoint/Service.pm
+++ b/perllib/Open311/Endpoint/Service.pm
@@ -37,6 +37,12 @@ has group => (
     default => '',
 );
 
+has groups => (
+    is => 'rw',
+    isa => ArrayRef[Str],
+    default => sub { [] },
+);
+
 has type => (
     is => 'ro',
     isa => Enum[qw/ realtime batch blackbox /],

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -129,7 +129,10 @@ subtest "GET Service List" => sub {
 <services>
   <service>
     <description>Flooding</description>
-    <group>Flooding,&quot;Flooding &amp; Drainage&quot;</group>
+    <groups>
+      <group>Flooding</group>
+      <group>Flooding &amp; Drainage</group>
+    </groups>
     <keywords></keywords>
     <metadata>true</metadata>
     <service_code>ABC_DEF</service_code>
@@ -395,7 +398,9 @@ subtest "GET Service List - private services" => sub {
 <services>
   <service>
     <description>Flooding</description>
-    <group>&quot;Flooding &amp; Drainage&quot;</group>
+    <groups>
+      <group>Flooding &amp; Drainage</group>
+    </groups>
     <keywords>private</keywords>
     <metadata>true</metadata>
     <service_code>ABC_DEF</service_code>


### PR DESCRIPTION
This seems nicer than CSV :)
Confirm will always use `groups`, others will continue to use group.