### PR TITLE
[Alloy] change the version id we use for updates numbers

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Alloy.pm
+++ b/perllib/Open311/Endpoint/Integration/Alloy.pm
@@ -329,7 +329,7 @@ sub get_service_request_updates {
             my %args = (
                 status => $status,
                 external_status_code => $reason_for_closure,
-                update_id => $resource->{version}->{resourceSystemVersionId},
+                update_id => $resource->{version}->{usedSystemVersionId},
                 service_request_id => $update->{resourceId},
                 description => $description_to_send,
                 updated_datetime => $update_dt,

--- a/t/open311/endpoint/json/alloy/resource_3027030_v271881.json
+++ b/t/open311/endpoint/json/alloy/resource_3027030_v271881.json
@@ -82,10 +82,10 @@
     }
   ],
   "version": {
-    "currentSystemVersionId": 271881,
+    "currentSystemVersionId": 271884,
     "endDate": "9999-12-31T00:00:00.000Z",
     "endSystemVersionId": null,
-    "resourceSystemVersionId": 271883,
+    "resourceSystemVersionId": 271884,
     "startDate": "2019-01-01T01:42:40Z",
     "startSystemVersionId": 268108,
     "usedDate": "2019-02-19T18:19:14.543Z",


### PR DESCRIPTION
use `usedSystemVersionId` instead of `resourceSystemVersionId`.