### PR TITLE
Remove unneeded test gubbins.

### DIFF
--- a/perllib/Integrations/WDM.pm
+++ b/perllib/Integrations/WDM.pm
@@ -30,11 +30,6 @@ has 'updates_endpoint' => (
     default => 'updates.xml',
 );
 
-has service_request_content => (
-    is => 'ro',
-    default => '/open311/service_request_extended'
-);
-
 sub format_datetime {
     my ($self, $dt) = @_;
 

--- a/perllib/Open311/Endpoint/Integration/Alloy.pm
+++ b/perllib/Open311/Endpoint/Integration/Alloy.pm
@@ -3,6 +3,7 @@ package Open311::Endpoint::Integration::Alloy;
 use Moo;
 use DateTime::Format::W3CDTF;
 use LWP::UserAgent;
+use Types::Standard ':all';
 extends 'Open311::Endpoint';
 with 'Open311::Endpoint::Role::mySociety';
 with 'Open311::Endpoint::Role::ConfigFile';
@@ -12,6 +13,7 @@ with 'Role::Logger';
 use Open311::Endpoint::Service::UKCouncil::Alloy;
 use Open311::Endpoint::Service::Attribute;
 use Open311::Endpoint::Service::Request::CanBeNonPublic;
+use Open311::Endpoint::Service::Request::Update::mySociety;
 
 use Path::Tiny;
 
@@ -30,6 +32,18 @@ has jurisdiction_id => (
 has '+request_class' => (
     is => 'ro',
     default => 'Open311::Endpoint::Service::Request::CanBeNonPublic',
+);
+
+has '+identifier_types' => (
+    is => 'lazy',
+    isa => HashRef[Any],
+    default => sub {
+        my $self = shift;
+        return {
+            # some service codes have spaces
+            service_code => { type => '/open311/regex', pattern => qr/^ [\w_\- \/\(\)]+ $/ax },
+        };
+    },
 );
 
 has alloy => (

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -288,10 +288,9 @@ has attribute_descriptions => (
     default => sub { {} }
 );
 
-has service_request_content => (
-    is => 'ro',
-    default => '/open311/service_request_extended'
-);
+sub service_request_content {
+    '/open311/service_request_extended'
+}
 
 has default_site_code => (
     is => 'ro',

--- a/perllib/Open311/Endpoint/Integration/SalesForce.pm
+++ b/perllib/Open311/Endpoint/Integration/SalesForce.pm
@@ -15,10 +15,9 @@ use Encode qw(encode_utf8);
 use Digest::MD5 qw(md5_hex);
 use DateTime::Format::Strptime;
 
-has service_request_content => (
-    is => 'ro',
-    default => '/open311/service_request_extended'
-);
+sub service_request_content {
+    '/open311/service_request_extended'
+}
 
 sub parse_datetime {
     my ($self, $time) = @_;

--- a/perllib/Open311/Endpoint/Integration/UK/Northamptonshire.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Northamptonshire.pm
@@ -18,10 +18,9 @@ has integration_class => (
     default => 'Integrations::Alloy::Northamptonshire'
 );
 
-has service_request_content => (
-    is => 'ro',
-    default => '/open311/service_request_extended'
-);
+sub service_request_content {
+    '/open311/service_request_extended'
+}
 
 sub process_attributes {
     my ($self, $source, $args) = @_;

--- a/perllib/Open311/Endpoint/Integration/WDM.pm
+++ b/perllib/Open311/Endpoint/Integration/WDM.pm
@@ -15,10 +15,9 @@ has service_class  => (
     default => 'Open311::Endpoint::Service::UKCouncil::Oxfordshire'
 );
 
-has service_request_content => (
-    is => 'ro',
-    default => '/open311/service_request_extended'
-);
+sub service_request_content {
+    '/open311/service_request_extended'
+}
 
 has '+request_class' => (
     is => 'ro',

--- a/t/open311/endpoint/alloy.t
+++ b/t/open311/endpoint/alloy.t
@@ -49,8 +49,7 @@ around BUILDARGS => sub {
     return $class->$orig(%args);
 };
 has integration_class => (is => 'ro', default => 'Integrations::Alloy::Dummy');
-sub jurisdiction_id { return 'dummy'; }
-has service_request_content => (is => 'ro', default => '/open311/service_request_extended');
+sub service_request_content { '/open311/service_request_extended' }
 
 package main;
 
@@ -70,9 +69,8 @@ use JSON::MaybeXS;
 use Path::Tiny;
 
 BEGIN { $ENV{TEST_MODE} = 1; }
-use Open311::Endpoint::Integration::UK;
 
-my $endpoint = Open311::Endpoint::Integration::UK->new;
+my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
 
 my %responses = (
     resource => '{


### PR DESCRIPTION
Make service_request_content always a function, which then means
we can improve a couple of test files to test their integrations
directly, rather than via the main UK one, so then we can remove
unneeded jurisdiction_id functions.