### PR TITLE
[Confirm] Add option to not set ContactName/Email/Phone when raising enquiries

### DIFF
--- a/conf/council-peterborough_confirm.yml-example
+++ b/conf/council-peterborough_confirm.yml-example
@@ -7,5 +7,6 @@
   "customer_type_code": "",
   "point_of_contact_code": "",
   "enquiry_method_code": "",
+  "skip_enquiry_contact_fields": true,
   "service_whitelist": {},
 }

--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -272,10 +272,12 @@ sub NewEnquiry {
         LoggedTime => $logged_time,
         ServiceCode => $service_code,
         SubjectCode => $subject_code,
-        ContactName => $args->{first_name} . " " . $args->{last_name},
-        ContactEmail => $args->{email},
-        ContactPhone => $args->{phone},
     );
+    unless ( $self->config->{skip_enquiry_contact_fields} ) {
+        $enq{ContactName} = $args->{first_name} . " " . $args->{last_name};
+        $enq{ContactEmail} = $args->{email};
+        $enq{ContactPhone} = $args->{phone};
+    }
     if ($args->{location}) {
         $enq{EnquiryLocation} = substr($args->{location}, 0, 2000);
     }


### PR DESCRIPTION
Peterborough only want customer details associated with the `EnquiryCustomer` record, not the `ContactName`/`ContactEmail`/`ContactPhone` fields on enquiries. This PR adds a config option to allow that behaviour.