### PR TITLE
[Bexley Confirm] Split into two separate integrations - trees and grounds

### DIFF
--- a/conf/council-bexley_confirm_grounds.yml-example
+++ b/conf/council-bexley_confirm_grounds.yml-example
@@ -8,4 +8,3 @@ ignored_attributes: []
 ignored_attribute_options: []
 forward_status_mapping: {}
 reverse_status_mapping: {}
-

--- a/conf/council-bexley_confirm_trees.yml-example
+++ b/conf/council-bexley_confirm_trees.yml-example
@@ -1,0 +1,10 @@
+endpoint_url: ""
+username: ""
+password: ""
+tenant_id: ""
+server_timezone: ""
+service_whitelist: {}
+ignored_attributes: []
+ignored_attribute_options: []
+forward_status_mapping: {}
+reverse_status_mapping: {}

--- a/perllib/Integrations/Confirm/BexleyGrounds.pm
+++ b/perllib/Integrations/Confirm/BexleyGrounds.pm
@@ -1,0 +1,19 @@
+package Integrations::Confirm::BexleyGrounds;
+
+use Path::Tiny;
+use Moo;
+extends 'Integrations::Confirm';
+with 'Role::Config';
+
+has config_filename => (
+    is => 'ro',
+    default => 'bexley_confirm_grounds',
+);
+
+sub _build_config_file {
+    my $self = shift;
+    # uncoverable statement
+    path(__FILE__)->parent(4)->realpath->child('conf/council-' . $self->config_filename . '.yml');
+}
+
+1;

--- a/perllib/Integrations/Confirm/BexleyTrees.pm
+++ b/perllib/Integrations/Confirm/BexleyTrees.pm
@@ -1,4 +1,4 @@
-package Integrations::Confirm::Bexley;
+package Integrations::Confirm::BexleyTrees;
 
 use Path::Tiny;
 use Moo;
@@ -7,7 +7,7 @@ with 'Role::Config';
 
 has config_filename => (
     is => 'ro',
-    default => 'bexley_confirm',
+    default => 'bexley_confirm_trees',
 );
 
 sub _build_config_file {

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmGrounds.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmGrounds.pm
@@ -1,0 +1,19 @@
+package Open311::Endpoint::Integration::UK::Bexley::ConfirmGrounds;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::Confirm';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'bexley_confirm_grounds';
+    return $class->$orig(%args);
+};
+
+use Integrations::Confirm::BexleyGrounds;
+
+has integration_class => (
+    is => 'ro',
+    default => 'Integrations::Confirm::BexleyGrounds'
+);
+
+1;

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmTrees.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmTrees.pm
@@ -1,19 +1,19 @@
-package Open311::Endpoint::Integration::UK::Bexley::Confirm;
+package Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees;
 
 use Moo;
 extends 'Open311::Endpoint::Integration::Confirm';
 
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
-    $args{jurisdiction_id} = 'bexley_confirm';
+    $args{jurisdiction_id} = 'bexley_confirm_trees';
     return $class->$orig(%args);
 };
 
-use Integrations::Confirm::Bexley;
+use Integrations::Confirm::BexleyTrees;
 
 has integration_class => (
     is => 'ro',
-    default => 'Integrations::Confirm::Bexley'
+    default => 'Integrations::Confirm::BexleyTrees'
 );
 
 1;

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -16,15 +16,6 @@ my $confirm_grounds = Test::MockModule->new('Open311::Endpoint::Integration::UK:
 $confirm_grounds->mock(services => sub {
     return ( new_service('A_BC'), new_service('D_EF') );
 });
-$confirm_grounds->mock(post_service_request_update => sub {
-    my ($self, $args) = @_;
-    is $args->{service_code}, 'D_EF';
-    is $args->{service_request_id}, 1001;
-    return Open311::Endpoint::Service::Request::Update::mySociety->new(
-        status => 'in_progress',
-        update_id => 456,
-    );
-});
 my $confirm_trees = Test::MockModule->new('Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees');
 $confirm_trees->mock(services => sub {
     return ( new_service('A_BC'), new_service('D_EF') );

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -18,7 +18,7 @@ $confirm_grounds->mock(services => sub {
 });
 my $confirm_trees = Test::MockModule->new('Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees');
 $confirm_trees->mock(services => sub {
-    return ( new_service('A_BC'), new_service('D_EF') );
+    return ( new_service('X_YZ'), new_service('D_EF') );
 });
 $confirm_trees->mock(post_service_request_update => sub {
     my ($self, $args) = @_;
@@ -72,12 +72,12 @@ subtest "GET Service List" => sub {
     <type>realtime</type>
   </service>
   <service>
-    <description>A_BC</description>
+    <description>X_YZ</description>
     <group></group>
     <keywords></keywords>
     <metadata>false</metadata>
-    <service_code>ConfirmTrees-A_BC</service_code>
-    <service_name>A_BC</service_name>
+    <service_code>ConfirmTrees-X_YZ</service_code>
+    <service_name>X_YZ</service_name>
     <type>realtime</type>
   </service>
   <service>
@@ -112,7 +112,7 @@ CONTENT
 };
 
 subtest "GET Service Definition" => sub {
-    my $res = $endpoint->run_test_request( GET => '/services/ConfirmTrees-A_BC.xml' );
+    my $res = $endpoint->run_test_request( GET => '/services/ConfirmGrounds-A_BC.xml' );
     ok $res->is_success, 'xml success',
         or diag $res->content;
     is_string $res->content, <<CONTENT, 'xml string ok';
@@ -120,7 +120,7 @@ subtest "GET Service Definition" => sub {
 <service_definition>
   <attributes>
   </attributes>
-  <service_code>ConfirmTrees-A_BC</service_code>
+  <service_code>ConfirmGrounds-A_BC</service_code>
 </service_definition>
 CONTENT
 

--- a/t/open311/endpoint/bexley_confirm.t
+++ b/t/open311/endpoint/bexley_confirm.t
@@ -9,7 +9,7 @@ use Test::MockModule;
 
 BEGIN { $ENV{TEST_MODE} = 1; }
 
-my $open311 = Test::MockModule->new('Integrations::Confirm::Bexley');
+my $open311 = Test::MockModule->new('Integrations::Confirm::BexleyTrees');
 $open311->mock(perform_request => sub {
     my ($self, $op) = @_; # Don't care about subsequent ops
     $op = $$op;
@@ -24,8 +24,8 @@ $open311->mock(perform_request => sub {
     return {};
 });
 
-use Open311::Endpoint::Integration::UK::Bexley::Confirm;
-my $endpoint = Open311::Endpoint::Integration::UK::Bexley::Confirm->new(
+use Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees;
+my $endpoint = Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees->new(
   config_file => path(__FILE__)->sibling("bexley_confirm.yml")->stringify,
 );
 


### PR DESCRIPTION
Bexley have two separate Confirm servers, one for trees and one for grounds. This change splits the Bexley Confirm integration in two so we can have one integration for each server.

There aren't separate tests for the trees and grounds integrations, since the implementations are virtually identical. I spoke to @dracos about this and we agreed that if/when the implementations diverge we can add tests at that point.

Related to https://github.com/mysociety/fixmystreet-commercial/issues/1568 and https://github.com/mysociety/fixmystreet-commercial/issues/1573 (since we need separate category and status mappings for the trees and grounds servers).