### PR TITLE
Add a logrotate example configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ local
 /conf/general.yml.deployed
 /conf/httpd.conf
 /conf/httpd.conf.deployed
+/conf/logrotate
+/conf/logrotate.deployed
 /conf/council-*
 !/conf/council-*-example
 /t/open311/test.log

--- a/conf/logrotate-example
+++ b/conf/logrotate-example
@@ -1,0 +1,10 @@
+# Example logrotate config file
+/path/to/logfile.log {
+  daily
+  missingok
+  rotate 7
+  compress
+  delaycompress
+  notifempty
+  copytruncate
+}


### PR DESCRIPTION
Example configuration for rotating the log file, together with some additions to `.gitignore` for deployed files.