### PR TITLE
[Bexley] Make sure service request ID updated on updates.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -464,6 +464,7 @@ sub post_service_request_update {
     my $update_id = $enquiry->{EnquiryNumber} .  "_" . $enquiry->{EnquiryLogNumber};
 
     return Open311::Endpoint::Service::Request::Update::mySociety->new(
+        service_request_id => $enquiry->{EnquiryNumber},
         status => lc $args->{status},
         update_id => $update_id,
     );

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley.pm
@@ -58,7 +58,13 @@ sub _map_with_new_id {
         if ($name eq $self->integration_without_prefix) {
             $result;
         } else {
-            (ref $result)->new(%$result, $attribute => "$name-" . $result->$attribute);
+            my %params;
+            $params{$attribute} = "$name-" . $result->$attribute;
+            # Also need to update the relevant request ID if it's an update
+            if ($attribute eq 'update_id') {
+                $params{service_request_id} = "$name-" . $result->service_request_id;
+            }
+            (ref $result)->new(%$result, %params);
         }
     } @results;
     return @results;

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -25,6 +25,7 @@ $confirm_trees->mock(post_service_request_update => sub {
     is $args->{service_code}, 'D_EF';
     is $args->{service_request_id}, 1001;
     return Open311::Endpoint::Service::Request::Update::mySociety->new(
+        service_request_id => 1001,
         status => 'in_progress',
         update_id => 456,
     );


### PR DESCRIPTION
I don't think anything uses this, and can't now recall how I realised it wasn't doing it, but I guess if a backend request ID is included in the response, it should be mapped to have the prefix like the update ID>