### PR TITLE
[Alloy] use correct service_code for fetched reports

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -47,3 +47,4 @@ requires 'Test::MockModule';
 requires 'Test::MockTime';
 requires 'Test::More';
 requires 'Test::Output';
+requires 'Test::Warn';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2585,6 +2585,17 @@ DISTRIBUTIONS
       Test::SharedFork 0.29
       Time::HiRes 0
       perl 5.008001
+  Test-Warn-0.36
+    pathname: B/BI/BIGJ/Test-Warn-0.36.tar.gz
+    provides:
+      Test::Warn 0.36
+    requirements:
+      Carp 1.22
+      ExtUtils::MakeMaker 0
+      Sub::Uplevel 0.12
+      Test::Builder 0.13
+      Test::Builder::Tester 1.02
+      perl 5.006
   Text-CSV-1.99
     pathname: I/IS/ISHIGAKI/Text-CSV-1.99.tar.gz
     provides:

--- a/perllib/Open311/Endpoint/Integration/Alloy.pm
+++ b/perllib/Open311/Endpoint/Integration/Alloy.pm
@@ -473,6 +473,12 @@ sub get_service_requests {
             next;
         }
 
+        my $category_service = $self->service($category);
+        unless ($category_service) {
+            warn "No matching service for $category for defect $request->{resourceId} in " . $self->jurisdiction_id . "\n";
+            next;
+        }
+
         $args{latlong} = $self->get_latlong_from_request($request);
 
         unless ($args{latlong}) {
@@ -695,7 +701,19 @@ sub get_defect_category {
         $category = $mapping->{types}->{$type} if $mapping->{types}->{$type};
     }
 
-    return $category;
+    return '' unless $category;
+
+    my %reverse_whitelist;
+    for my $group (sort keys %{ $self->service_whitelist }) {
+        my $whitelist = $self->service_whitelist->{$group};
+        for my $subcategory (sort keys %{ $whitelist }) {
+            next if $subcategory eq 'resourceId';
+            $reverse_whitelist{$subcategory} = $group;
+        }
+    }
+
+    my $cat_group = $reverse_whitelist{$category} || '';
+    return $cat_group . '_' . $category;
 }
 
 sub process_attributes {

--- a/t/open311/endpoint/alloy.t
+++ b/t/open311/endpoint/alloy.t
@@ -59,6 +59,7 @@ use Test::More;
 use Test::LongString;
 use Test::MockModule;
 use Test::MockTime ':all';
+use Test::Warn;
 use Encode;
 
 use Open311::Endpoint;
@@ -433,9 +434,19 @@ This is an update"
 
 subtest "check fetch problem" => sub {
     set_fixed_time('2014-01-01T12:00:00Z');
-    my $res = $endpoint->run_test_request(
-      GET => '/requests.json?jurisdiction_id=dummy&start_date=2019-01-02T00:00:00Z&end_date=2019-01-01T02:00:00Z',
-    );
+    my $res;
+    warnings_like {
+        $res = $endpoint->run_test_request(
+          GET => '/requests.json?jurisdiction_id=dummy&start_date=2019-01-02T00:00:00Z&end_date=2019-01-01T02:00:00Z',
+        );
+    }
+    [
+        qr/No category found for defect 4947502, source type 1000807 in alloy/,
+        qr{No matching service for _Stile-Damaged/Missing for defect 4947503},
+        qr/No category found for defect 4947596.*1000815 in alloy.*/,
+        qr/No category found for defect 4947670.*1000815 in alloy.*/,
+    ],
+    "warning issued for missing category";
 
     my $sent = pop @sent;
     ok $res->is_success, 'valid request'
@@ -445,9 +456,9 @@ subtest "check fetch problem" => sub {
     [{
       long => 1,
       requested_datetime => "2019-01-02T11:29:16Z",
-      service_code => "Shelter Damaged",
+      service_code => "Bus Stops_Shelter Damaged",
       updated_datetime => "2019-01-02T11:29:16Z",
-      service_name => "Shelter Damaged",
+      service_name => "Bus Stops_Shelter Damaged",
       address_id => "",
       lat => 2,
       description => "test",
@@ -462,7 +473,7 @@ subtest "check fetch problem" => sub {
       lat => 2,
       service_request_id => 4947597,
       description => "fill",
-      service_name => "Grit Bin - empty/refill",
+      service_name => "Winter_Grit Bin - empty/refill",
       status => "fixed",
       media_url => "",
       address => "",
@@ -470,8 +481,7 @@ subtest "check fetch problem" => sub {
       requested_datetime => "2019-01-02T14:44:53Z",
       long => 1,
       updated_datetime => "2019-01-02T14:44:53Z",
-      service_code => "Grit Bin - damaged/replacement",
-      service_code => "Grit Bin - empty/refill"
+      service_code => "Winter_Grit Bin - empty/refill",
    }], "correct json returned";
 };
 
@@ -547,6 +557,24 @@ subtest "check fetch service description" => sub {
         group => "Kerbs",
         service_name => "Missing",
         description => "Missing"
+    },
+    {
+        service_code => 'Winter_Grit Bin - damaged/replacement',
+        metadata => 'true',
+        type => "realtime",
+        keywords => "",
+        group => "Winter",
+        service_name => "Grit Bin - damaged/replacement",
+        description => "Grit Bin - damaged/replacement"
+    },
+    {
+        service_code => 'Winter_Grit Bin - empty/refill',
+        metadata => 'true',
+        type => "realtime",
+        keywords => "",
+        group => "Winter",
+        service_name => "Grit Bin - empty/refill",
+        description => "Grit Bin - empty/refill"
     } ], 'correct json returned';
 };
 

--- a/t/open311/endpoint/alloy.yml
+++ b/t/open311/endpoint/alloy.yml
@@ -62,6 +62,11 @@
       "Damaged/Loose": { "emergency": 0 },
       "Missing": { "emergency": 1 },
     },
+    "Winter": {
+      "resourceId": 6183645,
+      "Grit Bin - empty/refill": { "emergency": 0 },
+      "Grit Bin - damaged/replacement": { "emergency": 0 },
+    },
   },
 
   "emergency_text": "This is an emergency",
@@ -165,7 +170,7 @@
     1000813: { "default": 'Damaged/Loose', "types": {}, "asset_types": {} },
     1000822: { "default": 'Damaged / Missing / Facing Wrong Way', "types": {}, "asset_types": {} },
     1000818: { "default": 'Road Markings - Worn/Faded', "types": {}, "asset_types": {} },
-    1001028: { "default": 'Stile-Damaged/Missing', "types": {}, "asset_types": {} },
+    1000808: { "default": 'Stile-Damaged/Missing', "types": {}, "asset_types": {} },
     1001057: { "default": 'Damaged Speed Humps', "types": {}, "asset_types": {} },
     1000949: { "default": 'Fallen Tree', "types": {}, "asset_types": {} },
     1001035: { "default": 'Sign/Waymarking - Damaged/Missing', "types": {}, "asset_types": {} },


### PR DESCRIPTION
Add the group name to the front of the service code that is included in
fetched defects to match the service codes returned by the service call.
Alongside this add a check to make sure that the defect is using a
supported service code, and if not warn and skip the defect.