### PR TITLE
[Peterborough] Ezytreev integration

### DIFF
--- a/conf/council-peterborough_ezytreev.yml-example
+++ b/conf/council-peterborough_ezytreev.yml-example
@@ -1,0 +1,10 @@
+endpoint_url: ""
+username: ""
+password: ""
+forward_status_mapping: {}
+reverse_status_mapping: {}
+category_mapping:
+  categoryA:
+    name: "Category A"
+  categoryB:
+    name: "Category B"

--- a/perllib/Open311/Endpoint/Integration/Ezytreev.pm
+++ b/perllib/Open311/Endpoint/Integration/Ezytreev.pm
@@ -33,6 +33,10 @@ has ezytreev => (
     default => sub { Integrations::Ezytreev->new(config_filename => $_[0]->jurisdiction_id) }
 );
 
+sub get_integration {
+    return $_[0]->ezytreev;
+}
+
 has category_mapping => (
     is => 'lazy',
     default => sub { $_[0]->endpoint_config->{category_mapping} }

--- a/perllib/Open311/Endpoint/Integration/UK/Peterborough.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Peterborough.pm
@@ -1,12 +1,20 @@
 package Open311::Endpoint::Integration::UK::Peterborough;
 
 use Moo;
-extends 'Open311::Endpoint::Integration::Confirm';
+extends 'Open311::Endpoint::Integration::Multi';
 
-around BUILDARGS => sub {
-    my ($orig, $class, %args) = @_;
-    $args{jurisdiction_id} = 'peterborough_confirm';
-    return $class->$orig(%args);
-};
+use Module::Pluggable
+    search_path => ['Open311::Endpoint::Integration::UK::Peterborough'],
+    instantiate => 'new';
 
-1;
+has jurisdiction_id => (
+    is => 'ro',
+    default => 'peterborough',
+);
+
+has integration_without_prefix => (
+    is => 'ro',
+    default => 'Confirm',
+);
+
+__PACKAGE__->run_if_script;

--- a/perllib/Open311/Endpoint/Integration/UK/Peterborough/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Peterborough/Confirm.pm
@@ -1,0 +1,12 @@
+package Open311::Endpoint::Integration::UK::Peterborough::Confirm;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::Confirm';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'peterborough_confirm';
+    return $class->$orig(%args);
+};
+
+1;

--- a/perllib/Open311/Endpoint/Integration/UK/Peterborough/Ezytreev.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Peterborough/Ezytreev.pm
@@ -1,0 +1,12 @@
+package Open311::Endpoint::Integration::UK::Peterborough::Ezytreev;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::Ezytreev';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'peterborough_ezytreev';
+    return $class->$orig(%args);
+};
+
+__PACKAGE__->run_if_script;

--- a/t/open311/endpoint/uk.t
+++ b/t/open311/endpoint/uk.t
@@ -18,7 +18,6 @@ my %config_filenames = (
     'Open311::Endpoint::Integration::UK::Lincolnshire' => 'lincolnshire_confirm',
     'Open311::Endpoint::Integration::UK::Northamptonshire' => 'northamptonshire_alloy',
     'Open311::Endpoint::Integration::UK::Oxfordshire' => 'oxfordshire',
-    'Open311::Endpoint::Integration::UK::Peterborough' => 'peterborough_confirm',
     'Open311::Endpoint::Integration::UK::Rutland' => 'rutland',
 );
 
@@ -42,6 +41,23 @@ $endpoint = Open311::Endpoint::Integration::UK::Bexley->new;
     'Open311::Endpoint::Integration::UK::Bexley::ConfirmGrounds' => 'bexley_confirm_grounds',
     'Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees' => 'bexley_confirm_trees',
     'Open311::Endpoint::Integration::UK::Bexley::Uniform' => 'bexley_uniform',
+);
+
+foreach ($endpoint->plugins) {
+    my $integ = $_->get_integration;
+    my $name = delete $config_filenames{ref($_)};
+    is $integ->config_filename, $name;
+    is basename($integ->config_file), "council-$name.yml";
+}
+
+is_deeply \%config_filenames, {};
+
+use_ok('Open311::Endpoint::Integration::UK::Peterborough');
+
+$endpoint = Open311::Endpoint::Integration::UK::Peterborough->new;
+
+%config_filenames = (
+    'Open311::Endpoint::Integration::UK::Peterborough::Confirm' => 'peterborough_confirm',
 );
 
 foreach ($endpoint->plugins) {

--- a/t/open311/endpoint/uk.t
+++ b/t/open311/endpoint/uk.t
@@ -58,6 +58,7 @@ $endpoint = Open311::Endpoint::Integration::UK::Peterborough->new;
 
 %config_filenames = (
     'Open311::Endpoint::Integration::UK::Peterborough::Confirm' => 'peterborough_confirm',
+    'Open311::Endpoint::Integration::UK::Peterborough::Ezytreev' => 'peterborough_ezytreev',
 );
 
 foreach ($endpoint->plugins) {


### PR DESCRIPTION
This switches Peterborough to the new "multi" integration which was extracted from Bexley in #81, and then adds ezytreev integration, which was added in #85.

Part of [Peterborough Phase 2 - EzyTreev](https://github.com/mysociety/fixmystreet-commercial/milestone/37).