### PR TITLE
[Ezytreev] Include external_status_code in updates

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Ezytreev.pm
+++ b/perllib/Open311/Endpoint/Integration/Ezytreev.pm
@@ -137,6 +137,7 @@ sub get_service_request_updates {
                 service_request_id => "ezytreev-" . $enquiry->{EnqRef},
                 description => $status_description,
                 updated_datetime => $dt,
+                external_status_code => $enquiry_status->{EnquiryStatusCode},
             );
             push @updates, Open311::Endpoint::Service::Request::Update::mySociety->new(%update_args);
         }

--- a/t/open311/endpoint/ezytreev.t
+++ b/t/open311/endpoint/ezytreev.t
@@ -286,6 +286,7 @@ subtest 'GET service request updates OK' => sub {
                 description => "Works ordered",
                 service_request_id => "ezytreev-1001",
                 updated_datetime => "2020-01-10T13:18:00Z",
+                external_status_code => "T5",
             }
         ], 'correct json returned';
 };


### PR DESCRIPTION
This allows us to setup response templates in the admin which are triggered by specific external status codes.