### PR TITLE
[Ezytreev] Get update notes for certain status codes

### DIFF
--- a/conf/council-peterborough_ezytreev.yml-example
+++ b/conf/council-peterborough_ezytreev.yml-example
@@ -3,6 +3,7 @@ username: ""
 password: ""
 forward_status_mapping: {}
 reverse_status_mapping: {}
+statuses_to_show_notes_for: []
 category_mapping:
   categoryA:
     name: "Category A"

--- a/perllib/Open311/Endpoint/Integration/Ezytreev.pm
+++ b/perllib/Open311/Endpoint/Integration/Ezytreev.pm
@@ -133,16 +133,18 @@ sub get_service_request_updates {
         foreach my $enquiry_status (@{$enquiry->{StatusHistory}}) {
             # Ignore updates created by FMS
             next if $enquiry_status->{StatusByName} eq 'CRM System';
-            my $status = $self->reverse_status_mapping->{$enquiry_status->{EnquiryStatusCode}};
+
+            my $status_code = $enquiry_status->{EnquiryStatusCode};
+            my $status = $self->reverse_status_mapping->{$status_code};
             if (!$status) {
                 $self->logger->warn("Missing reverse status mapping for EnquiryStatus Code " .
-                    "$enquiry_status->{EnquiryStatusCode} (EnquiryStatusID $enquiry_status->{EnquiryStatusID})\n");
+                    "$status_code (EnquiryStatusID $enquiry_status->{EnquiryStatusID})\n");
                 $status = "open";
             }
             my $dt = $w3c->parse_datetime($enquiry_status->{StatusDate});
 
             my $description;
-            if ($self->statuses_to_show_notes_for->{$enquiry_status->{EnquiryStatusCode}}) {
+            if ($self->statuses_to_show_notes_for->{$status_code}) {
                 $description = $enquiry_status->{StatusInfo};
             } else {
                 my $status_description = $enquiry_status->{EnquiryStatusDescription};
@@ -156,7 +158,7 @@ sub get_service_request_updates {
                 service_request_id => "ezytreev-" . $enquiry->{EnqRef},
                 description => $description,
                 updated_datetime => $dt,
-                external_status_code => $enquiry_status->{EnquiryStatusCode},
+                external_status_code => $status_code,
             );
             push @updates, Open311::Endpoint::Service::Request::Update::mySociety->new(%update_args);
         }

--- a/t/open311/endpoint/ezytreev.t
+++ b/t/open311/endpoint/ezytreev.t
@@ -46,8 +46,19 @@ $lwp->mock(request => sub {
                             StatusByID => 'ENQ',
                             StatusByName => 'Enquiry System Test',
                             StatusDate => '2020-01-10T13:18:00Z',
-                            StatusInfo => '',
-                        }
+                            StatusInfo => 'Some public notes about this update',
+                        },
+                        {
+                            EnquiryStatusCode => '4A',
+                            EnquiryStatusDescription => 'No further action: problem on private land',
+                            EnquiryStatusID => 6015,
+                            PriorityCode => '',
+                            PriorityDescription => '',
+                            StatusByID => 'ENQ',
+                            StatusByName => 'Enquiry System Test',
+                            StatusDate => '2020-01-12T14:54:00Z',
+                            StatusInfo => 'Some private notes about this update',
+                        },
                     ]
                 }
             ]
@@ -69,10 +80,12 @@ my $endpoint_config = {
     },
     reverse_status_mapping => {
         T5 => 'investigating',
+        '4A' => 'no_further_action',
     },
     forward_status_mapping => {
         FIXED => 'T8',
     },
+    statuses_to_show_notes_for => [qw(T1 T2 T3 T4 T5 T6 T7 T8)],
 };
 
 my $ezytreev_open311_mock = Test::MockModule->new('Open311::Endpoint::Integration::Ezytreev');
@@ -283,10 +296,19 @@ subtest 'GET service request updates OK' => sub {
                 media_url => '',
                 status => "investigating",
                 update_id => "ezytreev-update-6014",
-                description => "Works ordered",
+                description => "Some public notes about this update",
                 service_request_id => "ezytreev-1001",
                 updated_datetime => "2020-01-10T13:18:00Z",
                 external_status_code => "T5",
+            },
+            {
+                media_url => '',
+                status => "no_further_action",
+                update_id => "ezytreev-update-6015",
+                description => "No further action: problem on private land",
+                service_request_id => "ezytreev-1001",
+                updated_datetime => "2020-01-12T14:54:00Z",
+                external_status_code => "4A",
             }
         ], 'correct json returned';
 };


### PR DESCRIPTION
We want to pass the update notes for certain status codes through to FMS. This change adds a whitelist of codes that we allow the notes for and then checks that list when retrieving updates and shows the notes if it's in the whitelist, otherwise it just shows the enquiry status description.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1752