### PR TITLE
[Ezytreev] Ignore duplicate status updates

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Ezytreev.pm
+++ b/perllib/Open311/Endpoint/Integration/Ezytreev.pm
@@ -134,6 +134,11 @@ sub get_service_request_updates {
             # Ignore updates created by FMS
             next if $enquiry_status->{StatusByName} eq 'CRM System';
 
+            # Ignore updates that relate to creating/attaching order items as
+            # these result in duplicate status updates appearing for the same
+            # status code.
+            next if $enquiry_status->{StatusInfo} =~ m#^Enquiry created/attached to order item \d+#;
+
             my $status_code = $enquiry_status->{EnquiryStatusCode};
             my $status = $self->reverse_status_mapping->{$status_code};
             if (!$status) {

--- a/t/open311/endpoint/ezytreev.t
+++ b/t/open311/endpoint/ezytreev.t
@@ -59,6 +59,17 @@ $lwp->mock(request => sub {
                             StatusDate => '2020-01-12T14:54:00Z',
                             StatusInfo => 'Some private notes about this update',
                         },
+                        {
+                            EnquiryStatusCode => 'T5',
+                            EnquiryStatusDescription => 'Works ordered',
+                            EnquiryStatusID => 6016,
+                            PriorityCode => '',
+                            PriorityDescription => '',
+                            StatusByID => 'ENQ',
+                            StatusByName => 'Enquiry System Test',
+                            StatusDate => '2020-01-12T15:00:00Z',
+                            StatusInfo => 'Enquiry created/attached to order item 5312',
+                        }
                     ]
                 }
             ]


### PR DESCRIPTION
When an enquiry is attached to an order item it results in two status updates being generated for one status code. Ignore the update that has the order item ID in it, since this ID will be meaningless to the user anyway.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1753

## Todo

- [x] Change the base branch to `peterborough-reviewed` once #91 has been merged.