### PR TITLE
[Oxfordshire] ignore new feature_id attribute

### DIFF
--- a/perllib/Open311/Endpoint/Service/UKCouncil/Oxfordshire.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/Oxfordshire.pm
@@ -43,7 +43,7 @@ has '+attributes' => (
             variable => 0, # set by server
             datatype => 'string',
             required => 0,
-            automated => 'server_set',
+            automated => 'hidden_field',
             description => 'usrn',
         ),
         Open311::Endpoint::Service::Attribute->new(
@@ -78,22 +78,15 @@ has '+attributes' => (
             automated => 'server_set',
             description => 'service_type',
         ),
+        Open311::Endpoint::Service::Attribute->new(
+            code => 'feature_id',
+            variable => 0, # set by server
+            datatype => 'string',
+            required => 0,
+            automated => 'hidden_field',
+            description => 'feature_id',
+        ),
     ] },
-);
-
-has internal_attributes => (
-  is => 'ro',
-  default => sub { {
-      external_id => 1,
-      title => 1,
-      description => 1,
-      closest_address => 1,
-      usrn => 1,
-      easting => 1,
-      northing => 1,
-      service_detail => 1,
-      service_type => 1,
-  } },
 );
 
 1;

--- a/t/open311/endpoint/oxfordshire.t
+++ b/t/open311/endpoint/oxfordshire.t
@@ -154,6 +154,10 @@ for my $test (
         test_desc => 'create problem with no usrn',
         usrn => undef,
     },
+    {
+        test_desc => 'create problem with feature_id',
+        feature_id => 100,
+    },
 ) {
     subtest $test->{test_desc} => sub {
         set_fixed_time('2014-01-01T12:00:00Z');
@@ -179,6 +183,7 @@ for my $test (
         );
 
         $post_args{ 'attribute[usrn]' } = $args->{usrn} if $args->{usrn};
+        $post_args{ 'attribute[feature_id]' } = $args->{feature_id} if $args->{feature_id};
         my $res = $endpoint->run_test_request( POST => '/requests.json', %post_args );
 
         my $sent = pop @sent;


### PR DESCRIPTION
small change to handle the feature_id asset we're now using now that we have assets.