### PR TITLE
[WDM] enable statuses to be mapped

### DIFF
--- a/perllib/Integrations/WDM.pm
+++ b/perllib/Integrations/WDM.pm
@@ -164,6 +164,14 @@ sub get_updates {
     return $updates;
 }
 
+sub map_status {
+    my ($self, $status) = @_;
+
+    if ($self->config->{status_map}->{$status}) {
+        $status = $self->config->{status_map}->{$status};
+    }
+    return $status;
+}
 
 sub soap_post {
     my ($self, $url, $method, $tag_name, $data) = @_;

--- a/perllib/Open311/Endpoint/Integration/WDM.pm
+++ b/perllib/Open311/Endpoint/Integration/WDM.pm
@@ -88,6 +88,7 @@ sub get_service_request_updates {
         $customer_reference =~ s/\s*$//;
         my $status = lc $update->{STATUS};
         $status =~ s/ /_/g;
+        $status = $self->get_integration->map_status($status);
 
         my %args = (
             status => $status,

--- a/t/open311/endpoint/oxfordshire.t
+++ b/t/open311/endpoint/oxfordshire.t
@@ -431,6 +431,53 @@ subtest "fetch single update" => sub {
     $responses{'SOAP GetWdmUpdates'} = $current_reponse;
 };
 
+subtest "fetch mapped status update" => sub {
+    set_fixed_time('2014-01-01T12:00:00Z');
+    my $current_reponse = $responses{'SOAP GetWdmUpdates'};
+    $responses{'SOAP GetWdmUpdates'} = '
+        <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+             <GetWdmUpdatesResponse xmlns="http://www.wdm.co.uk/remedy/">
+             <GetWdmUpdatesResult>
+             <NewDataSet>
+             <wdmupdate>
+                <UpdateID>101</UpdateID>
+                <ENQUIRY_UID>123</ENQUIRY_UID>
+                <ENQUIRY_REFERENCE>ENQ123</ENQUIRY_REFERENCE>
+                <UPDATE_TIME>2018-07-05T16:03:13.334+01:00</UPDATE_TIME>
+                <EXTERNAL_SYSTEM_REFERENCE>1234</EXTERNAL_SYSTEM_REFERENCE>
+                <STATUS>mapped_status</STATUS>
+                <COMMENTS>Pothole has been filled</COMMENTS>
+            </wdmupdate>
+            </NewDataSet>
+            </GetWdmUpdatesResult>
+            </GetWdmUpdatesResponse>
+          </soap:Body>
+        </soap:Envelope>
+        ';
+
+    my $res = $endpoint->run_test_request(
+      GET => '/servicerequestupdates.json?jurisdiction_id=oxfordshire&start_date=2018-02-01T12:00:00Z&end_date=2018-02-02T12:00:00Z',
+    );
+
+    my $sent = pop @sent;
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+    [ {
+        status => 'in_progress',
+        service_request_id => '1234',
+        description => 'Pothole has been filled',
+        updated_datetime => '2018-07-05T16:03:13+01:00',
+        update_id => '101',
+        customer_reference => 'ENQ123',
+        media_url => '',
+    } ], 'correct json returned';
+
+    $responses{'SOAP GetWdmUpdates'} = $current_reponse;
+};
+
 subtest "fetch single update with no further action" => sub {
     set_fixed_time('2014-01-01T12:00:00Z');
     my $current_reponse = $responses{'SOAP GetWdmUpdates'};

--- a/t/open311/endpoint/oxfordshire.yml
+++ b/t/open311/endpoint/oxfordshire.yml
@@ -6,5 +6,8 @@
         "type": "POT_type",
         "detail": "POT_detail"
       }
+    },
+    "status_map": {
+      "mapped_status": "in_progress"
     }
 }


### PR DESCRIPTION
add a status_map key to the config and use that to map from WDM statuses
in fetched updates to FixMyStreet statuses