### PR TITLE
[EastSussex] allow groups to be renamed for display

### DIFF
--- a/t/open311/endpoint/eastsussex.t
+++ b/t/open311/endpoint/eastsussex.t
@@ -178,6 +178,43 @@ subtest "post for a single group item" => sub {
     is_deeply decode_json($res->content), [ { service_request_id => '00123456' } ], 'correct return';
 };
 
+subtest "post with renamed group" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        jurisdiction_id => 'eastsussex_salesforce',
+        api_key => 'test',
+        service_code => 'Workmanship',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        email => 'test@example.com',
+        description => 'description',
+        lat => '50',
+        long => '0.1',
+        'attribute[group]' => 'Roadworks',
+        'attribute[fixmystreet_id]' => 1,
+    );
+
+    my $sent = pop @sent;
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($sent), {
+        Type => 'Our Roadworks',
+        Sub_Type__c => 'Workmanship',
+        Description => 'description',
+        Latitude => 50,
+        Longitude => 0.1,
+        Subject => 'Our Roadworks',
+        CreatedDate => undef,
+        Location_Description__c => '22 Acacia Avenue',
+        AccountId => 1,
+        Origin => 'FMS',
+    }, 'correct request sent';
+
+    is_deeply decode_json($res->content), [ { service_request_id => '00123456' } ], 'correct return';
+};
+
 subtest "post that creates an account" => sub {
     my $res = $endpoint->run_test_request(
         POST => '/requests.json',
@@ -313,6 +350,24 @@ subtest "check fetch service description" => sub {
         type => "realtime",
         keywords => "",
         groups => [ "Signs" ]
+    },
+    {
+        service_code => "Traffic Management",
+        service_name => "Traffic Management",
+        description => "Traffic Management",
+        metadata => 'true',
+        type => "realtime",
+        keywords => "",
+        groups => [ "Roadworks" ]
+    },
+    {
+        service_code => "Workmanship",
+        service_name => "Workmanship",
+        description => "Workmanship",
+        metadata => 'true',
+        type => "realtime",
+        keywords => "",
+        groups => [ "Roadworks" ]
     },
     {
         service_code => "Bridges, Walls & Tunnels",

--- a/t/open311/endpoint/eastsussex.yml
+++ b/t/open311/endpoint/eastsussex.yml
@@ -11,6 +11,7 @@
   service_whitelist: [
     "Abandoned Vehicle",
     "Bridges, Walls & Tunnels",
+    "Our Roadworks",
     "Signs",
   ],
 
@@ -20,6 +21,10 @@
     "Staff Contact",
     "Claim",
   ],
+
+  group_name_map: {
+    'Our Roadworks': 'Roadworks',
+  },
 
   field_map: {
     group: "Type",

--- a/t/open311/endpoint/services.json
+++ b/t/open311/endpoint/services.json
@@ -89,6 +89,13 @@
           "label": "Media Enquiries",
           "validFor": null,
           "value": "Media Enquiries"
+        },
+        {
+          "active": true,
+          "defaultValue": false,
+          "label": "Our Roadworks",
+          "validFor": null,
+          "value": "Our Roadworks"
         }
       ],
       "polymorphicForeignKey": false,
@@ -233,6 +240,20 @@
           "label": "Warning Signs",
           "validFor": "QAAA",
           "value": "Warning Signs"
+        },
+        {
+          "active": true,
+          "defaultValue": false,
+          "label": "Traffic Management",
+          "validFor": "BAAA",
+          "value": "Traffic Management"
+        },
+        {
+          "active": true,
+          "defaultValue": false,
+          "label": "Workmanship",
+          "validFor": "BAAA",
+          "value": "Workmanship"
         }
       ],
       "polymorphicForeignKey": false,


### PR DESCRIPTION
Some of the internal Salesforce names aren't especially user facing so
allow them to be renamed on the way out and then reversed on the way
back in