### PR TITLE
[EastSussex] filter groups at a service level

### DIFF
--- a/t/open311/endpoint/eastsussex.t
+++ b/t/open311/endpoint/eastsussex.t
@@ -367,7 +367,7 @@ subtest "check fetch service description" => sub {
         metadata => 'true',
         type => "realtime",
         keywords => "",
-        groups => [ "Roadworks" ]
+        groups => [ "Abandoned Vehicle" ]
     },
     {
         service_code => "Bridges, Walls & Tunnels",

--- a/t/open311/endpoint/eastsussex.yml
+++ b/t/open311/endpoint/eastsussex.yml
@@ -26,6 +26,10 @@
     'Our Roadworks': 'Roadworks',
   },
 
+  group_service_blacklist: {
+      "Signs": [ "Workmanship" ]
+  },
+
   field_map: {
     group: "Type",
     service_code: "Sub_Type__c",

--- a/t/open311/endpoint/services.json
+++ b/t/open311/endpoint/services.json
@@ -237,6 +237,13 @@
         {
           "active": true,
           "defaultValue": false,
+          "label": "Workmanship",
+          "validFor": "QAAA",
+          "value": "Workmanship"
+        },
+        {
+          "active": true,
+          "defaultValue": false,
           "label": "Warning Signs",
           "validFor": "QAAA",
           "value": "Warning Signs"
@@ -252,7 +259,7 @@
           "active": true,
           "defaultValue": false,
           "label": "Workmanship",
-          "validFor": "BAAA",
+          "validFor": "gAAA",
           "value": "Workmanship"
         }
       ],


### PR DESCRIPTION
Some service names appear under multiple groups but we don't want to
display all of them. Add a blacklist that filters out groups from
services.