### PR TITLE
[Bartec] correctly map fetched requests catgories

### DIFF
--- a/t/open311/endpoint/bartec.t
+++ b/t/open311/endpoint/bartec.t
@@ -681,6 +681,33 @@ subtest 'fetch_requests' => sub {
     ], 'correct list of requests';
 };
 
+subtest 'fetch_requests with mapped service' => sub {
+    my $res = $endpoint->run_test_request(
+        GET => '/requests.json?jurisdiction_id=bartec&start_date=2020-06-22T10:00:00Z&end_date=2022-06-20T12:00:00Z'
+    );
+
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+
+    is_deeply decode_json($res->content), [
+        {
+            lat => "52.543786",
+            long => "-0.567652",
+            address_id => "",
+            service_request_id => "SR5",
+            address => "",
+            requested_datetime => "2020-06-24T16:17:00+01:00",
+            updated_datetime => "2020-06-24T16:17:00+01:00",
+            media_url => "",
+            status => "open",
+            service_name => "Offensive graffiti",
+            zipcode => "",
+            service_code => "281"
+        }
+    ], 'correct list of requests';
+};
+
 subtest 'fetch_requests with no results' => sub {
     %sent = ();
 

--- a/t/open311/endpoint/xml/bartec/servicerequests_get_SR5.xml
+++ b/t/open311/endpoint/xml/bartec/servicerequests_get_SR5.xml
@@ -1,0 +1,81 @@
+    <ServiceRequests_GetResponse xmlns="http://bartec-systems.com/">
+      <ServiceRequests_GetResult xmlns="http://www.bartec-systems.com/ServiceRequests_Get.xsd" RecordCount="1">
+        <ServiceRequest>
+          <id xmlns="http://www.bartec-systems.com">51395</id>
+          <ServiceCode xmlns="http://www.bartec-systems.com">SR5</ServiceCode>
+          <Premises xmlns="http://www.bartec-systems.com">
+            <UPRN>10000000001</UPRN>
+            <USRN>20000001</USRN>
+            <Address>
+              <Address1/>
+              <Address2>30</Address2>
+              <Street>A STREET</Street>
+              <Locality>NEIGHBOURHOOD</Locality>
+              <Town>PETERBOROUGH</Town>
+              <PostCode>PE7 8GE</PostCode>
+            </Address>
+            <Location>
+              <BNG Easting="517572.970437695" Northing="295392.962529791"/>
+              <Metric Latitude="52.543786" Longitude="-0.567652"/>
+            </Location>
+            <RecordStamp>
+              <AddedBy>dbo</AddedBy>
+              <DateAdded>2018-11-12T14:22:23.3</DateAdded>
+            </RecordStamp>
+          </Premises>
+          <ServiceLocation xmlns="http://www.bartec-systems.com">
+            <BNG Easting="537574.431717046" Northing="245405.572821964"/>
+            <Metric Latitude="52.543786" Longitude="-0.567652"/>
+          </ServiceLocation>
+          <DateRequested xmlns="http://www.bartec-systems.com">2020-06-24T16:17:00</DateRequested>
+          <ServiceType xmlns="http://www.bartec-systems.com">
+            <ID>281</ID>
+            <Name>GENERAL</Name>
+            <Description>GENERAL</Description>
+            <AppointmentCount>0</AppointmentCount>
+            <ServiceClass>
+              <ID>84</ID>
+              <Name>OFFENSIVE GRAFFITI</Name>
+              <Description>OFFENSIVE GRAFFITI</Description>
+              <Category>General</Category>
+              <Mobile>false</Mobile>
+              <Private>false</Private>
+              <RecordStamp>
+                <DateAdded>0001-01-01T00:00:00</DateAdded>
+              </RecordStamp>
+              <ExtendedDataRecordDefinitionID xsi:nil="true"/>
+            </ServiceClass>
+            <ExtendedDataRecordDefinitionID xsi:nil="true"/>
+          </ServiceType>
+          <ServiceStatus xmlns="http://www.bartec-systems.com">
+            <ID>2644</ID>
+            <Status>OPEN</Status>
+            <SequenceNumber>2</SequenceNumber>
+            <ServiceTypeID>270</ServiceTypeID>
+          </ServiceStatus>
+          <ExternalReference xmlns="http://www.bartec-systems.com"></ExternalReference>
+          <SLA xmlns="http://www.bartec-systems.com">
+            <ID>35</ID>
+            <Name>SLA - 1 Working Day</Name>
+            <Description>SLA - 1 Working Day</Description>
+            <JeopardyPeriod>         4 Hours</JeopardyPeriod>
+            <WorkingHours>false</WorkingHours>
+            <SLAStatus>OK</SLAStatus>
+            <BreachTime>0001-01-01T00:00:00</BreachTime>
+            <JeopardyTime>2020-06-23T19:17:00</JeopardyTime>
+          </SLA>
+          <LicenceApplication xmlns="http://www.bartec-systems.com">
+            <PaymentType/>
+            <WebPageType/>
+          </LicenceApplication>
+          <RecordStamp xmlns="http://www.bartec-systems.com">
+            <AddedBy>a_user</AddedBy>
+            <DateAdded>2020-06-23T16:17:31.397</DateAdded>
+          </RecordStamp>
+        </ServiceRequest>
+        <Errors>
+          <Result xmlns="http://www.bartec-systems.com">0</Result>
+          <Message xmlns="http://www.bartec-systems.com"/>
+        </Errors>
+      </ServiceRequests_GetResult>
+    </ServiceRequests_GetResponse>

--- a/t/open311/endpoint/xml/bartec/servicerequests_updates_get_20200622.xml
+++ b/t/open311/endpoint/xml/bartec/servicerequests_updates_get_20200622.xml
@@ -1,0 +1,18 @@
+    <ServiceRequests_Updates_GetResponse xmlns="http://bartec-systems.com/">
+      <ServiceRequests_Updates_GetResult xmlns="http://www.bartec-systems.com/ServiceRequests_Updates_Get.xsd" RecordCount="11">
+        <ServiceRequest_Updates RecordCount="0">
+          <ServiceRequestID>51395</ServiceRequestID>
+          <ServiceCode>SR5</ServiceCode>
+          <JobReference/>
+          <ServiceCategory>General</ServiceCategory>
+          <ServiceClass>OFFENSIVE GRAFFITI</ServiceClass>
+          <ServiceType>GENERAL</ServiceType>
+          <DateAdded>0001-01-01T00:00:00</DateAdded>
+          <DateChanged>2020-06-24T16:17:00.007</DateChanged>
+        </ServiceRequest_Updates>
+        <Errors>
+          <Result xmlns="http://www.bartec-systems.com">0</Result>
+          <Message xmlns="http://www.bartec-systems.com"/>
+        </Errors>
+      </ServiceRequests_Updates_GetResult>
+    </ServiceRequests_Updates_GetResponse>


### PR DESCRIPTION
Factor out the service request name generating code so we can use it to
make sure service requests with mapped categories get the correct name.
And use the existing code to check for allowed categories for the same
reason.