### PR TITLE
[Northamptonshire] move extra status config to file

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/Northamptonshire.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Northamptonshire.pm
@@ -87,9 +87,10 @@ sub get_request_description {
 sub process_update_state {
     my ($self, $status, $reason_for_closure) = @_;
 
-    if ( $status eq 'further_investigation' ) {
-        $status = 'investigating';
-        $reason_for_closure = 'further'
+    my $mapping = $self->config->{status_and_closure_mapping};
+    if ( my $map = $mapping->{$status} ) {
+        $reason_for_closure = $map->{reason_for_closure};
+        $status = $map->{status};
     }
 
     return ($status, $reason_for_closure);

--- a/t/open311/endpoint/alloy.yml
+++ b/t/open311/endpoint/alloy.yml
@@ -162,6 +162,13 @@
     4281526: 'no_further_action', # highways to monitor
   },
 
+  "status_and_closure_mapping": {
+    "further_investigation": {
+      "status": "investigating",
+      "reason_for_closure": "further"
+    }
+  },
+
   "inspection_resource_name": "INSPECTION_STANDARD INSPECTION_STANDARD",
 
   "defect_sourcetype_category_mapping": {


### PR DESCRIPTION
Rather than have code to set the reason for closure and status for non
standard statuses, do this in the config file for ease of expansion.

Part of mysociety/fixmystreet-commercial#1952