### PR TITLE
[Central Beds] Set NextActionUserName field according to area_code attribute

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/CentralBedfordshire.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/CentralBedfordshire.pm
@@ -13,4 +13,17 @@ has jurisdiction_id => (
 # Updates from FMS should always have a GN11 code, meaning "Customer called"
 sub event_action_event_type { 'GN11'}
 
+sub process_service_request_args {
+    my $self = shift;
+
+    my $area_code = (delete $_[0]->{attributes}->{area_code}) || '';
+    my @args = $self->SUPER::process_service_request_args(@_);
+    my $response = $args[0];
+
+    my $lookup = $self->endpoint_config->{area_to_username};
+    $response->{NextActionUserName} ||= $lookup->{$area_code};
+
+    return @args;
+}
+
 1;

--- a/perllib/Open311/Endpoint/Service/UKCouncil/Symology.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/Symology.pm
@@ -31,6 +31,13 @@ sub _build_attributes {
             required => 0,
             automated => 'server_set',
         ),
+        Open311::Endpoint::Service::Attribute->new(
+            code => "area_code",
+            description => "Area code",
+            datatype => "string",
+            required => 0,
+            automated => 'server_set',
+        ),
     );
 
     return \@attributes;

--- a/t/open311/endpoint/bexley_symology.t
+++ b/t/open311/endpoint/bexley_symology.t
@@ -265,6 +265,16 @@ subtest "GET service" => sub {
              "required" => "false",
              "order" => 7,
              "datatype" => "string",
+             "code" => "area_code",
+             "description" => "Area code",
+             "variable" => "true",
+             "datatype_description" => "",
+             "automated" => "server_set"
+          },
+          {
+             "required" => "false",
+             "order" => 8,
+             "datatype" => "string",
              "code" => "message",
              "description" => "Please ignore yellow cars",
              "variable" => "false",
@@ -272,7 +282,7 @@ subtest "GET service" => sub {
           },
           {
              "required" => "true",
-             "order" => 8,
+             "order" => 9,
              "datatype" => "string",
              "code" => "car_details",
              "description" => "Car details",
@@ -281,7 +291,7 @@ subtest "GET service" => sub {
           },
           {
              "required" => "true",
-             "order" => 9,
+             "order" => 10,
              "datatype" => "singlevaluelist",
              "code" => "burnt",
              "description" => "Burnt out?",


### PR DESCRIPTION
Adds config & code to set the `NextActionUserName` field according to the incoming Open311 `area_code` attribute.

Counterpart to https://github.com/mysociety/fixmystreet/pull/3205