### PR TITLE
[Bexley] Handle private comments field

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/Bexley.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley.pm
@@ -17,4 +17,20 @@ has integration_without_prefix => (
     default => 'Symology',
 );
 
+around post_service_request => sub {
+    my ($orig, $class, $integration, $report) = @_;
+
+    # Add private comments
+    my $private_comments = delete $report->{attributes}{private_comments};
+    $report->{description} .= "\nPrivate comments: " . $private_comments if $private_comments;
+
+    # Confirm overwrites the description with the one from the attributes,
+    # so add private comments there as well.
+    if ($report->{attributes}->{description}) {
+        $report->{attributes}->{description} .= "\nPrivate comments: " . $private_comments if $private_comments;
+    }
+
+    return $class->$orig($integration, $report);
+};
+
 __PACKAGE__->run_if_script;

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmGrounds.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmGrounds.pm
@@ -3,6 +3,13 @@ package Open311::Endpoint::Integration::UK::Bexley::ConfirmGrounds;
 use Moo;
 extends 'Open311::Endpoint::Integration::Confirm';
 
+use Open311::Endpoint::Service::UKCouncil::BexleyConfirm;
+
+has service_class  => (
+    is => 'ro',
+    default => 'Open311::Endpoint::Service::UKCouncil::BexleyConfirm'
+);
+
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
     $args{jurisdiction_id} = 'bexley_confirm_grounds';

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmTrees.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/ConfirmTrees.pm
@@ -3,6 +3,13 @@ package Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees;
 use Moo;
 extends 'Open311::Endpoint::Integration::Confirm';
 
+use Open311::Endpoint::Service::UKCouncil::BexleyConfirm;
+
+has service_class  => (
+    is => 'ro',
+    default => 'Open311::Endpoint::Service::UKCouncil::BexleyConfirm'
+);
+
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
     $args{jurisdiction_id} = 'bexley_confirm_trees';

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
@@ -5,9 +5,16 @@ package Open311::Endpoint::Integration::UK::Bexley::Symology;
 use Moo;
 extends 'Open311::Endpoint::Integration::Symology';
 
+use Open311::Endpoint::Service::UKCouncil::BexleySymology;
+
 has jurisdiction_id => (
     is => 'ro',
     default => 'bexley_symology',
+);
+
+has service_class  => (
+    is => 'ro',
+    default => 'Open311::Endpoint::Service::UKCouncil::BexleySymology'
 );
 
 sub process_service_request_args {

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/Uniform.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/Uniform.pm
@@ -3,6 +3,13 @@ package Open311::Endpoint::Integration::UK::Bexley::Uniform;
 use Moo;
 extends 'Open311::Endpoint::Integration::Uniform';
 
+use Open311::Endpoint::Service::UKCouncil::BexleyUniform;
+
+has service_class  => (
+    is => 'ro',
+    default => 'Open311::Endpoint::Service::UKCouncil::BexleyUniform'
+);
+
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
     $args{jurisdiction_id} = 'bexley_uniform';

--- a/perllib/Open311/Endpoint/Role/BexleyPrivateComments.pm
+++ b/perllib/Open311/Endpoint/Role/BexleyPrivateComments.pm
@@ -1,0 +1,15 @@
+package Open311::Endpoint::Role::BexleyPrivateComments;
+
+use Moo::Role;
+
+sub private_comments_attribute {
+  Open311::Endpoint::Service::Attribute->new(
+      code => "private_comments",
+      description => "Private comments",
+      datatype => "string",
+      required => 0,
+      automated => 'server_set',
+  )
+}
+
+1;

--- a/perllib/Open311/Endpoint/Service/UKCouncil/BexleyConfirm.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/BexleyConfirm.pm
@@ -1,0 +1,21 @@
+package Open311::Endpoint::Service::UKCouncil::BexleyConfirm;
+
+use Moo;
+extends 'Open311::Endpoint::Service::UKCouncil::Confirm';
+with 'Open311::Endpoint::Role::BexleyPrivateComments';
+
+use Open311::Endpoint::Service::Attribute;
+
+sub _build_attributes {
+    my $self = shift;
+
+    my @attributes = (
+        @{ $self->SUPER::_build_attributes() },
+
+        $self->private_comments_attribute,
+    );
+
+    return \@attributes;
+}
+
+1;

--- a/perllib/Open311/Endpoint/Service/UKCouncil/BexleySymology.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/BexleySymology.pm
@@ -1,0 +1,21 @@
+package Open311::Endpoint::Service::UKCouncil::BexleySymology;
+
+use Moo;
+extends 'Open311::Endpoint::Service::UKCouncil::Symology';
+with 'Open311::Endpoint::Role::BexleyPrivateComments';
+
+use Open311::Endpoint::Service::Attribute;
+
+sub _build_attributes {
+    my $self = shift;
+
+    my @attributes = (
+        @{ $self->SUPER::_build_attributes() },
+
+        $self->private_comments_attribute,
+    );
+
+    return \@attributes;
+}
+
+1;

--- a/perllib/Open311/Endpoint/Service/UKCouncil/BexleyUniform.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/BexleyUniform.pm
@@ -1,0 +1,21 @@
+package Open311::Endpoint::Service::UKCouncil::BexleyUniform;
+
+use Moo;
+extends 'Open311::Endpoint::Service::UKCouncil::Uniform';
+with 'Open311::Endpoint::Role::BexleyPrivateComments';
+
+use Open311::Endpoint::Service::Attribute;
+
+sub _build_attributes {
+    my $self = shift;
+
+    my @attributes = (
+        @{ $self->SUPER::_build_attributes() },
+
+        $self->private_comments_attribute,
+    );
+
+    return \@attributes;
+}
+
+1;

--- a/t/open311/endpoint/bexley_private_comments.t
+++ b/t/open311/endpoint/bexley_private_comments.t
@@ -1,0 +1,96 @@
+package Open311::Endpoint::Integration::UK::Dummy;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::UK::Bexley';
+
+use Module::Pluggable
+    search_path => ['Open311::Endpoint::Integration::UK::Dummy'],
+    instantiate => 'new';
+
+has integration_without_prefix => (
+    is => 'ro',
+    default => 'ConfirmTrees',
+);
+
+package Open311::Endpoint::Integration::UK::Dummy::ConfirmTrees;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::UK::Bexley::ConfirmTrees';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{config_data} = '
+service_whitelist:
+  Trees:
+    TREE_BRANCH: Fallen branches
+';
+    return $class->$orig(%args);
+};
+
+package main;
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::MockModule;
+
+use Open311::Endpoint::Integration::UK::Dummy;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
+
+my $confirm_integration = Test::MockModule->new('Integrations::Confirm');
+$confirm_integration->mock(config => sub {
+    {
+        web_url => 'http://www.example.org/web',
+        tenant_id => 'dummy',
+        server_timezone => 'Europe/London',
+    }
+});
+$confirm_integration->mock(perform_request => sub {
+    my ($self, $op) = @_; # Don't care about subsequent ops
+    $op = $$op;
+    if ($op->name && $op->name eq 'GetEnquiryLookups') {
+        return {
+            OperationResponse => { GetEnquiryLookupsResponse => { TypeOfService => [
+                { ServiceCode => 'TREE', ServiceName => 'Fallen branches', EnquirySubject => [ { SubjectCode => "BRANCH" } ] },
+            ] } }
+        };
+    }
+    $op = $op->value;
+    if ($op->name eq 'NewEnquiry') {
+        # Check that private comments are included in the description.
+        my %req = map { $_->name => $_->value } ${$op->value}->value;
+        is $req{EnquiryDescription}, "This is the details\nPrivate comments: Testing private comments";
+        return { OperationResponse => { NewEnquiryResponse => { Enquiry => { EnquiryNumber => 2001 } } } };
+    }
+});
+
+subtest "Sending private comments to Confirm when creating new report" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        api_key => 'test',
+        service_code => 'TREE_BRANCH',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the details",
+        'attribute[easting]' => 100,
+        'attribute[northing]' => 100,
+        'attribute[fixmystreet_id]' => 1001,
+        'attribute[title]' => 'Title',
+        'attribute[description]' => 'This is the details',
+        'attribute[report_url]' => 'http://example.com/report/1001',
+        'attribute[private_comments]' => "Testing private comments",
+    );
+
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    # Test for private comments appearing in description is in the `perform_request`
+    # mock above this test.
+};
+
+done_testing;

--- a/t/open311/endpoint/bexley_symology.t
+++ b/t/open311/endpoint/bexley_symology.t
@@ -277,6 +277,16 @@ subtest "GET service" => sub {
              "required" => "false",
              "order" => 8,
              "datatype" => "string",
+             "code" => "private_comments",
+             "description" => "Private comments",
+             "variable" => "true",
+             "datatype_description" => "",
+             "automated" => "server_set"
+          },
+          {
+             "required" => "false",
+             "order" => 9,
+             "datatype" => "string",
              "code" => "message",
              "description" => "Please ignore yellow cars",
              "variable" => "false",
@@ -284,7 +294,7 @@ subtest "GET service" => sub {
           },
           {
              "required" => "true",
-             "order" => 9,
+             "order" => 10,
              "datatype" => "string",
              "code" => "car_details",
              "description" => "Car details",
@@ -293,7 +303,7 @@ subtest "GET service" => sub {
           },
           {
              "required" => "true",
-             "order" => 10,
+             "order" => 11,
              "datatype" => "singlevaluelist",
              "code" => "burnt",
              "description" => "Burnt out?",


### PR DESCRIPTION
This is to work with the changes at the FixMyStreet end to send private comments over when they are entered on the report form.

I tried putting the `sub _build_attributes` bit into the `BexleyPrivateComments` role, but you can't use the `SUPER` pseudo-class from a role because it refers to the package rather than the object ([source](https://perldoc.perl.org/perlobj#How-SUPER-is-Resolved)).

The FixMyStreet bits are in https://github.com/mysociety/fixmystreet/pull/3222

Part of https://github.com/mysociety/fixmystreet-commercial/issues/1850