### PR TITLE
[Symology] Config to add a prefix to external ID when sending to Symology

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/Symology.pm
@@ -60,6 +60,11 @@ has customer_defaults => (
     default => sub { $_[0]->endpoint_config->{customer_defaults} }
 );
 
+has external_id_prefix => (
+    is => 'lazy',
+    default => sub { $_[0]->endpoint_config->{external_id_prefix} || "" }
+);
+
 # May want something like Confirm's service_assigned_officers
 
 sub services {
@@ -129,6 +134,8 @@ sub process_service_request_args {
             $request->{$_} = delete $args->{attributes}->{$_};
         }
     }
+
+    $request->{fixmystreet_id} = $self->external_id_prefix . $request->{fixmystreet_id};
 
     if ($args->{media_url}->[0]) {
         foreach my $photo_url (@{ $args->{media_url} }) {
@@ -235,7 +242,7 @@ sub process_service_request_update_args {
         Description => $args->{description},
         ServiceCode => $codes->{parameters}{ServiceCode},
         CRNo => $args->{service_request_id},
-        fixmystreet_id => $args->{service_request_id_ext},
+        fixmystreet_id => $self->external_id_prefix . $args->{service_request_id_ext},
         UserName => $self->username,
     };
     $request->{EventType} = $self->event_action_event_type($request);

--- a/t/open311/endpoint/bexley_symology.t
+++ b/t/open311/endpoint/bexley_symology.t
@@ -56,6 +56,8 @@ $soap_lite->mock(call => sub {
         is $request[REPORT_DESC]->value, "This is the details$photo_desc\n\nBurnt out?: $burnt\n\nCar details: M4 GIC, red Ford Focus";
         is $request[REPORT_PRIORITY]->value, $request[REPORT_EASTING]->value == EASTING_GOOD_BURNT ? 'P1' : "N";
         if ($request[REPORT_EASTING]->value == EASTING_BAD) {
+            is $request[REPORT_INWEB]->value, "123";
+            is $request[REPORT_REF]->value, "123";
             return {
                 StatusCode => 1,
                 StatusMessage => 'Failed',

--- a/t/open311/endpoint/centralbedfordshire.t
+++ b/t/open311/endpoint/centralbedfordshire.t
@@ -61,6 +61,8 @@ $soap_lite->mock(call => sub {
         is $request[REPORT_PRIORITY]->value, ($request[REPORT_REQUEST_TYPE]->value eq "Bridges" ? 'Priority1' : 'Priority2');
         if ( $request[REPORT_REQUEST_TYPE]->value eq "Potholes" ) {
             is $request[REPORT_NEXTACTIONUSERNAME]->value, 'POT00001';
+            is $request[REPORT_INWEB]->value, "FMS456";
+            is $request[REPORT_REF]->value, "FMS456";
         } elsif ( $request[REPORT_EASTING]->value == EASTING_AREAA ) {
             is $request[REPORT_NEXTACTIONUSERNAME]->value, 'USER0001';
         } elsif ( $request[REPORT_EASTING]->value == EASTING_AREAB ) {
@@ -91,9 +93,7 @@ $soap_lite->mock(call => sub {
     } elsif ($args[0] eq 'SendEventAction') {
         my @request = map { $_->value } ${$args[2]->value}->value;
         my $photo_desc = "\n\n[ This update contains a photo, see: http://example.org/photo/1.jpeg ]";
-        my $report_id = $request[2];
-        my $code = 'GN11';
-        is_deeply \@request, [ 'ServiceCode', 1001, $report_id, $code, '', 'FMS', "This is the update$photo_desc" ];
+        is_deeply \@request, [ 'ServiceCode', 1001, "FMS123", "GN11", '', 'FMS', "This is the update$photo_desc" ];
         return {
             StatusCode => 0,
             StatusMessage => 'Event Loaded',
@@ -169,6 +169,7 @@ $centralbeds_end->mock(endpoint_config => sub {
         updates_sftp => {
             out => path(__FILE__)->sibling('files/centralbedfordshire/updates')->stringify,
         },
+        external_id_prefix => "FMS",
     }
 });
 


### PR DESCRIPTION
This means we can potentially filter out non-FMS reports when fetching updates to hopefully speed things up a bit.