### PR TITLE
[Bartec] Add per-service Open311 keywords

### DIFF
--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -39,6 +39,18 @@ sub credentials {
     );
 }
 
+sub collective_endpoint {
+    my $config = $_[0]->config;
+
+    return $config->{collective_endpoint};
+}
+
+sub auth_endpoint {
+    my $config = $_[0]->config;
+
+    return $config->{auth_endpoint};
+}
+
 has memcache_namespace  => (
     is => 'lazy',
     default => sub { $_[0]->config_filename }
@@ -179,9 +191,11 @@ has service_extended_data_map => (
 
 
 sub _methods {
+    my $self = shift;
+
     return {
         'Authenticate' => {
-            endpoint   => 'https://collapi.bartec-systems.com/CollAuth/Authenticate.asmx',
+            endpoint   => $self->auth_endpoint,
             soapaction => 'http://bartec-systems.com/Authenticate',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -190,13 +204,13 @@ sub _methods {
             ],
         },
         'Premises_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/Premises_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [],
         },
         'ServiceRequests_Types_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Types_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -204,7 +218,7 @@ sub _methods {
             ],
         },
         'ServiceRequests_Notes_Types_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Notes_Types_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -212,7 +226,7 @@ sub _methods {
             ],
         },
         'ServiceRequests_Updates_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Updates_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -221,7 +235,7 @@ sub _methods {
             ],
         },
         'ServiceRequests_History_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_History_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -232,25 +246,25 @@ sub _methods {
             ],
         },
         'ServiceRequests_Create' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Create',
             namespace  => 'http://bartec-systems.com/',
             parameters => [],
         },
         'Service_Request_Document_Create' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/Service_Request_Document_Create',
             namespace  => 'http://bartec-systems.com/',
             parameters => [],
         },
         'ServiceRequests_Notes_Create' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Notes_Create',
             namespace  => 'http://bartec-systems.com/',
             parameters => [],
         },
         'System_ExtendedDataDefinitions_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/System_ExtendedDataDefinitions_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -259,7 +273,7 @@ sub _methods {
             ],
         },
         'ServiceRequests_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -268,7 +282,7 @@ sub _methods {
             ],
         },
         'ServiceRequests_Detail_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Detail_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [
@@ -277,7 +291,7 @@ sub _methods {
             ],
         },
         'ServiceRequests_Statuses_Get' => {
-            endpoint   => 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx',
+            endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Statuses_Get',
             namespace  => 'http://bartec-systems.com/',
             parameters => [

--- a/perllib/Open311/Endpoint/Integration/Bartec.pm
+++ b/perllib/Open311/Endpoint/Integration/Bartec.pm
@@ -75,6 +75,8 @@ sub services {
     my $services = $self->get_integration->ServiceRequests_Types_Get;
     $services = $self->get_integration->_coerce_to_array( $services, 'ServiceType' );
 
+    my $keywords_map = $self->get_integration->config->{service_keywords};
+
     my @services = map {
         my ($service_name, $class) = $self->_get_service_name($_);
 
@@ -83,6 +85,7 @@ sub services {
             service_code => $_->{ID},
             description => $_->{Description},
             groups => [ $class ],
+            keywords => $keywords_map->{$_->{ID}} || [],
       );
     } grep { $self->_allowed_service($_) } @$services;
     return @services;

--- a/t/integrations/bartec.t
+++ b/t/integrations/bartec.t
@@ -4,6 +4,10 @@ use Moo;
 extends 'Integrations::Bartec';
 sub _build_config_file { path(__FILE__)->sibling('bartec.yml')->stringify }
 
+sub collective_endpoint { 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx' }
+
+sub auth_endpoint { 'https://collapi.bartec-systems.com/CollAuth/Authenticate.asmx' }
+
 sub get_integration {
     my $self = shift;
     my $integ = Integrations::Bartec::Dummy->new;

--- a/t/open311/endpoint/bartec.t
+++ b/t/open311/endpoint/bartec.t
@@ -202,6 +202,15 @@ subtest "check fetch service description" => sub {
         keywords => "",
         groups => [ "Graffiti" ]
     },
+    {
+        service_code => "6",
+        service_name => "Food",
+        description => "Food",
+        metadata => 'true',
+        type => "realtime",
+        keywords => "waste_only",
+        groups => [ "Missed collection" ]
+    },
     ],
     'correct services returned';
 };

--- a/t/open311/endpoint/bartec.yml
+++ b/t/open311/endpoint/bartec.yml
@@ -12,6 +12,10 @@ service_map:
     General:
       group: Graffiti
       category: Offensive graffiti
+  Missed bin:
+    Missed food:
+      group: Missed collection
+      category: Food
 
 extended_data:
    Rubbish (Street cleansing):
@@ -64,3 +68,6 @@ uprn_lookup:
 address_match:
   100:
     - OPEN SPACE
+
+service_keywords:
+  6: [ waste_only ]

--- a/t/open311/endpoint/bartec.yml
+++ b/t/open311/endpoint/bartec.yml
@@ -1,5 +1,7 @@
 username: username
 password: password
+collective_endpoint: https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx
+auth_endpoint: https://collapi.bartec-systems.com/CollAuth/Authenticate.asmx
 
 allowed_services:
   - Leaf Removal

--- a/t/open311/endpoint/xml/bartec/servicerequests_types_get.xml
+++ b/t/open311/endpoint/xml/bartec/servicerequests_types_get.xml
@@ -300,5 +300,55 @@
           </RecordStamp>
           <ExtendedDataRecordDefinitionID xmlns="http://www.bartec-systems.com">0</ExtendedDataRecordDefinitionID>
         </ServiceType>
+        <ServiceType>
+          <ID xmlns="http://www.bartec-systems.com">6</ID>
+          <Name xmlns="http://www.bartec-systems.com">Missed food</Name>
+          <Description xmlns="http://www.bartec-systems.com">Missed food</Description>
+          <AppointmentCount xmlns="http://www.bartec-systems.com">1</AppointmentCount>
+          <ServiceClass xmlns="http://www.bartec-systems.com">
+            <ID>3</ID>
+            <Name>Missed bin</Name>
+            <Description>Missed bin</Description>
+            <Category>General</Category>
+            <ExtendedDataRecordType xsi:nil="true" />
+            <Mobile>false</Mobile>
+            <Private>false</Private>
+            <RecordStamp xsi:nil="true" />
+            <ExtendedDataRecordDefinitionID>0</ExtendedDataRecordDefinitionID>
+          </ServiceClass>
+          <DefaultCrew xmlns="http://www.bartec-systems.com">
+            <ID>1</ID>
+            <CrewNumber>2</CrewNumber>
+            <WorkGroup xsi:nil="true" />
+            <Description>A Crew</Description>
+            <DefaultSize>2</DefaultSize>
+            <StartTime></StartTime>
+            <EndTime></EndTime>
+            <WorkingMinutes>60</WorkingMinutes>
+            <NonworkingMinutes>30</NonworkingMinutes>
+            <RecordStamp xsi:nil="true" />
+          </DefaultCrew>
+          <DefaultLandType xmlns="http://www.bartec-systems.com">
+            <ID>2</ID>
+            <Name>Lant Type</Name>
+            <RecordStamp xsi:nil="true" />
+          </DefaultLandType>
+          <DefaultSLA xmlns="http://www.bartec-systems.com">
+            <ID>2</ID>
+            <Name>An SLA</Name>
+            <Description>An SLA</Description>
+            <Period>7 days</Period>
+            <NormaliseTime></NormaliseTime>
+            <JeopardyPeriod></JeopardyPeriod>
+            <WorkingHours>true</WorkingHours>
+            <RecordStamp xsi:nil="true" />
+          </DefaultSLA>
+          <RecordStamp xmlns="http://www.bartec-systems.com">
+            <AddedBy>A User</AddedBy>
+            <DateAdded></DateAdded>
+            <Comments></Comments>
+          </RecordStamp>
+          <ExtendedDataRecordDefinitionID xmlns="http://www.bartec-systems.com">0</ExtendedDataRecordDefinitionID>
+        </ServiceType>
      </ServiceRequests_Types_GetResult>
  </ServiceRequests_Types_GetResponse>


### PR DESCRIPTION
 - Makes it possible to add keywords to Open311 service definitions in the YAML config
 - Puts Bartec endpoint URLs in config for easier local debugging/testing