### PR TITLE
[Echo] Prevent encoding of string values.

### DIFF
--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -25,6 +25,10 @@ has endpoint => (
         $soap->on_action( sub { $self->action . $_[1]; } );
         $soap->on_fault(sub { my($soap, $res) = @_; die ref $res ? $res->fault->{Reason}{Text} : $soap->transport->status, "\n"; });
         $soap->serializer->register_ns("http://schemas.microsoft.com/2003/10/Serialization/Arrays", 'msArray'),
+        # Prevent Base64 encoding
+        my $lookup = $soap->serializer->typelookup;
+        $lookup->{base64Binary}->[0] = 1000;
+        $soap->serializer->typelookup($lookup);
         return $soap;
     },
 );

--- a/t/open311/endpoint/echo.t
+++ b/t/open311/endpoint/echo.t
@@ -23,6 +23,7 @@ package main;
 
 use strict;
 use warnings;
+use utf8;
 
 BEGIN { $ENV{TEST_MODE} = 1; }
 
@@ -82,7 +83,11 @@ $soap_lite->mock(call => sub {
         } elsif ($event_type == EVENT_TYPE_ENQUIRY) {
             my @notes = ${$data[3]->value}->value;
             is $notes[0]->value, 1008;
-            is $notes[1]->value, 'These are some notes';
+            is $notes[1]->value, 'These are some notes 🎉';
+
+            # Check serialisation as well
+            my $envelope = $cls->serializer->envelope(method => $method, @notes);
+            like $envelope, qr/These are some notes 🎉/;
         }
 
         my $client_ref = $params[1]->value;
@@ -270,7 +275,7 @@ subtest "POST general enquiry OK" => sub {
         'attribute[service_id]' => 531, # Domestic refuse
         'attribute[uprn]' => 1000001,
         'attribute[fixmystreet_id]' => 2000123,
-        'attribute[Notes]' => "These are some notes",
+        'attribute[Notes]' => "These are some notes 🎉",
     );
     ok $res->is_success, 'valid request'
         or diag $res->content;


### PR DESCRIPTION
The previous fix for this in Symology was the not-great-commit-message cac33c510274a6fc7ab5801d4f8e847bda906973, but I wasn't sure if any other types were being used here (e.g. integers being sent as integers), so thought it easier just to disable base64 encoding as an output instead, otherwise leaving the normal detection alone.