### PR TITLE
[Echo] allow client reference to be customised

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -158,6 +158,10 @@ sub process_service_request_args {
     my $service = $args->{attributes}{service_id} || '';
     my $uprn = $args->{attributes}{uprn};
     my $fixmystreet_id = $args->{attributes}{fixmystreet_id} || '';
+    my $client_reference = "FMS-$fixmystreet_id";
+    if ( $args->{attributes}{client_reference} ) {
+        $client_reference = $args->{attributes}{client_reference};
+    }
 
     # Missed collections have different event types depending
     # on the service
@@ -173,7 +177,7 @@ sub process_service_request_args {
         event_type => $event_type,
         service => $service,
         uprn => $uprn,
-        client_reference => "FMS-$fixmystreet_id",
+        client_reference => $client_reference,
         data => [],
     };
 

--- a/t/open311/endpoint/echo.t
+++ b/t/open311/endpoint/echo.t
@@ -141,7 +141,11 @@ $soap_lite->mock(call => sub {
         }
 
         my $client_ref = $params[1]->value;
-        is $client_ref, 'FMS-2000123';
+        if ( $uprn == 1000002 ) {
+            is $client_ref, 'client_ref1234';
+        } else {
+            is $client_ref, 'FMS-2000123';
+        }
 
         return SOAP::Result->new(result => {
             EventGuid => '1234',
@@ -423,6 +427,7 @@ subtest "POST subscription request with containter request OK" => sub {
         'attribute[Subscription_Details_Quantity]' => 2,
         'attribute[Container_Request_Container_Type]' => 44, # Garden Waste
         'attribute[Container_Request_Quantity]' => 1,
+        'attribute[client_reference]' => 'client_ref1234',
         'attribute[Type]' => 1,
     );
     ok $res->is_success, 'valid request'


### PR DESCRIPTION
Override the default client reference for an event if there is a
client_reference attribute in the request.