### PR TITLE
[Bexley] use Symology Event Type as external status

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/Symology.pm
@@ -333,12 +333,15 @@ sub get_service_request_updates {
     return @updates;
 }
 
+sub _row_external_status_code { return undef; }
+
 sub _process_csv_row {
     my ($self, $row) = @_;
 
     my $dt = $self->date_formatter->parse_datetime($row->{date_history});
 
     my $status = $self->_row_status($row);
+    my $external_status = $self->_row_external_status_code($row, $status);
     return unless $status;
     my $description = $self->_row_description($row);
 
@@ -351,6 +354,7 @@ sub _process_csv_row {
         service_request_id => $row->{CRNo}+0,
         description => $description,
         updated_datetime => $dt,
+        $external_status ? ( external_status_code => $external_status ) : (),
     );
 }
 

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
@@ -55,13 +55,13 @@ sub _row_status {
             'fixed'
         } elsif ($action_due =~ /^[NS][1-6]$/) {
             'in_progress'
-        } elsif ($action_due eq 'IR') {
+        } elsif ($action_due =~ /^IR|REH|RES|RET|RP|RPOS|RT|RWT$/) {
             'internal_referral'
         } elsif ($action_due eq 'NCR') {
             'not_councils_responsibility'
         } elsif ($action_due =~ /^([NS]I[1-6]MOB|IPSGM|IGF|IABV)$/) {
             'investigating'
-        } elsif ($action_due =~ /^PT[CS]$/) {
+        } elsif ($action_due =~ /^PT[CS]|TPHR|REIN$/) {
             'action_scheduled'
         } elsif ($row->{Stage} == 9) {
             undef

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
@@ -71,6 +71,12 @@ sub _row_status {
     };
 }
 
+sub _row_external_status_code {
+    my ($self, $row, $status) = @_;
+    return undef unless $status && $status eq 'not_councils_responsibility';
+    return $row->{'Event Type'};
+}
+
 sub _row_description { '' } # lca description not used
 
 1;

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
@@ -73,7 +73,9 @@ sub _row_status {
 
 sub _row_external_status_code {
     my ($self, $row, $status) = @_;
-    return undef unless $status && $status eq 'not_councils_responsibility';
+    return undef unless $status && ( $status eq 'not_councils_responsibility'
+                        || $status eq 'action_scheduled'
+                        || $status eq 'internal_referral' );
     return $row->{'Event Type'};
 }
 

--- a/t/open311/endpoint/bexley_symology.t
+++ b/t/open311/endpoint/bexley_symology.t
@@ -120,8 +120,8 @@ $bexley_end->mock(_get_csvs => sub {
 14/03/2019 07:32,13/03/2019,569924,CLEARED,14/03/2019,NI2,NI2MOB,,,9
 17/04/2019 12:05,04/04/2019,560065,RECORDED,,SI6,S6,S6,,1
 17/04/2019 12:05,04/04/2019,560064,RECORDED,,SI6,PTC,PTC,,1
-17/04/2019 12:32,02/04/2019,560057,RECORDED,,NI3,NI3MOB,PTS,,1
-17/04/2019 13:29,04/04/2019,560063,RECORDED,,SI6,S5,NCR,,1
+17/04/2019 12:32,02/04/2019,560057,RECORDED,,NI3,NI3MOB,PTS,ROH,1
+17/04/2019 13:29,04/04/2019,560063,RECORDED,,SI6,S5,NCR,RLQ,1
 17/04/2019 13:34,02/04/2019,560056,RECORDED,,SI6,SI6MOB,SI6MOB,,1
 17/04/2019 13:49,17/04/2019,560067,RECORDED,,SI4,S4,CLEARREQ,,1
 17/04/2019 13:50,04/04/2019,560058,RECORDED,,SI6,SI6MOB,IR,,1
@@ -503,7 +503,7 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560057_9d1bacb4",
+              "update_id" => "560057_13d32550",
               "updated_datetime" => "2019-04-17T12:32:00+01:00",
               "service_request_id" => "560057",
               "status" => "action_scheduled",
@@ -511,12 +511,13 @@ subtest "GET updates OK" => sub {
               "media_url" => "",
            },
            {
-              "update_id" => "560063_cb783d63",
+              "update_id" => "560063_c5f60f35",
               "updated_datetime" => "2019-04-17T13:29:00+01:00",
               "service_request_id" => "560063",
               "status" => "not_councils_responsibility",
               "description" => "",
               "media_url" => "",
+              "external_status_code" => 'RLQ',
            },
            {
               "update_id" => "560056_caf47a7e",

--- a/t/open311/endpoint/bexley_symology.t
+++ b/t/open311/endpoint/bexley_symology.t
@@ -125,6 +125,7 @@ $bexley_end->mock(_get_csvs => sub {
 17/04/2019 13:34,02/04/2019,560056,RECORDED,,SI6,SI6MOB,SI6MOB,,1
 17/04/2019 13:49,17/04/2019,560067,RECORDED,,SI4,S4,CLEARREQ,,1
 17/04/2019 13:50,04/04/2019,560058,RECORDED,,SI6,SI6MOB,IR,,1
+17/04/2019 13:53,04/04/2019,560058,RECORDED,,SI6,SI6MOB,IR,RES,1
 17/04/2019 14:08,04/04/2019,560062,RECORDED,,SI5,NCR,CR,,1
 EOF
     \<<EOF
@@ -509,6 +510,7 @@ subtest "GET updates OK" => sub {
               "status" => "action_scheduled",
               "description" => "",
               "media_url" => "",
+              "external_status_code" => 'ROH',
            },
            {
               "update_id" => "560063_c5f60f35",
@@ -542,6 +544,15 @@ subtest "GET updates OK" => sub {
               "status" => "internal_referral",
               "description" => "",
               "media_url" => "",
+           },
+           {
+              "update_id" => "560058_456d3988",
+              "updated_datetime" => "2019-04-17T13:53:00+01:00",
+              "service_request_id" => "560058",
+              "status" => "internal_referral",
+              "description" => "",
+              "media_url" => "",
+              "external_status_code" => 'RES',
            },
            {
               "update_id" => "560062_94e427db",


### PR DESCRIPTION
Use the Event Type column as the external status code if present in the
update CSV.

Fixes mysociety/fixmystreet-commercial#2279