### PR TITLE
Switch O::E::I:: config to endpoint_config.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Ezytreev.pm
+++ b/perllib/Open311/Endpoint/Integration/Ezytreev.pm
@@ -1,7 +1,6 @@
 package Open311::Endpoint::Integration::Ezytreev;
 
 use JSON::MaybeXS;
-use Path::Tiny;
 use Digest::MD5 qw(md5_hex);
 use DateTime::Format::W3CDTF;
 
@@ -12,7 +11,7 @@ use Open311::Endpoint::Service::Request::Update::mySociety;
 use Moo;
 extends 'Open311::Endpoint';
 with 'Open311::Endpoint::Role::mySociety';
-with 'Role::Config';
+with 'Role::EndpointConfig';
 with 'Role::Logger';
 
 has jurisdiction_id => (
@@ -30,23 +29,23 @@ sub get_integration {
 
 has category_mapping => (
     is => 'lazy',
-    default => sub { $_[0]->config->{category_mapping} }
+    default => sub { $_[0]->endpoint_config->{category_mapping} }
 );
 
 has forward_status_mapping => (
     is => 'lazy',
-    default => sub { $_[0]->config->{forward_status_mapping} }
+    default => sub { $_[0]->endpoint_config->{forward_status_mapping} }
 );
 
 has reverse_status_mapping => (
     is => 'lazy',
-    default => sub { $_[0]->config->{reverse_status_mapping} }
+    default => sub { $_[0]->endpoint_config->{reverse_status_mapping} }
 );
 
 has statuses_to_show_notes_for => (
     is => 'lazy',
     default => sub {
-        return { map { $_ => 1 } @{$_[0]->config->{statuses_to_show_notes_for}} };
+        return { map { $_ => 1 } @{$_[0]->endpoint_config->{statuses_to_show_notes_for}} };
     }
 );
 

--- a/perllib/Open311/Endpoint/Integration/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/Symology.pm
@@ -7,14 +7,13 @@ use DateTime::Format::Strptime;
 use DateTime::Format::W3CDTF;
 use Digest::MD5 qw(md5_hex);
 use Moo;
-use Path::Tiny;
 use JSON::MaybeXS;
 use Text::CSV;
 use YAML::Logic;
 
 extends 'Open311::Endpoint';
 with 'Open311::Endpoint::Role::mySociety';
-with 'Role::Config';
+with 'Role::EndpointConfig';
 with 'Role::Logger';
 
 use Integrations::Symology;
@@ -33,27 +32,27 @@ has date_formatter => ( is => 'lazy', default => sub {
 
 has category_mapping => (
     is => 'lazy',
-    default => sub { $_[0]->config->{category_mapping} }
+    default => sub { $_[0]->endpoint_config->{category_mapping} }
 );
 
 has username => (
     is => 'lazy',
-    default => sub { $_[0]->config->{username} }
+    default => sub { $_[0]->endpoint_config->{username} }
 );
 
 has update_urls => (
     is => 'lazy',
-    default => sub { $_[0]->config->{update_urls} }
+    default => sub { $_[0]->endpoint_config->{update_urls} }
 );
 
 has customer_defaults => (
     is => 'lazy',
-    default => sub { $_[0]->config->{customer_defaults} }
+    default => sub { $_[0]->endpoint_config->{customer_defaults} }
 );
 
 has external_id_prefix => (
     is => 'lazy',
-    default => sub { $_[0]->config->{external_id_prefix} || "" }
+    default => sub { $_[0]->endpoint_config->{external_id_prefix} || "" }
 );
 
 # May want something like Confirm's service_assigned_officers

--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/Symology.pm
@@ -22,7 +22,7 @@ sub process_service_request_args {
     my @args = $self->SUPER::process_service_request_args(@_);
     my $request = $args[0];
 
-    my $lookup = $self->config->{nsgref_to_action};
+    my $lookup = $self->endpoint_config->{nsgref_to_action};
     $request->{NextAction} = $lookup->{$request->{NSGRef} || ''} || 'S6';
 
     return @args;

--- a/perllib/Open311/Endpoint/Integration/UK/CentralBedfordshire.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/CentralBedfordshire.pm
@@ -20,7 +20,7 @@ sub process_service_request_args {
     my @args = $self->SUPER::process_service_request_args(@_);
     my $response = $args[0];
 
-    my $lookup = $self->config->{area_to_username};
+    my $lookup = $self->endpoint_config->{area_to_username};
     $response->{NextActionUserName} ||= $lookup->{$area_code};
 
     return @args;
@@ -29,7 +29,7 @@ sub process_service_request_args {
 sub _get_csvs {
     my $self = shift;
 
-    my $dir = $self->config->{updates_sftp}->{out};
+    my $dir = $self->endpoint_config->{updates_sftp}->{out};
     my @files = glob "$dir/*.CSV";
     return \@files;
 }
@@ -45,7 +45,7 @@ sub _event_description {
 sub _event_status {
     my ($self, $event) = @_;
 
-    my $map = $self->config->{event_status_mapping}->{$event->{HistoryType}};
+    my $map = $self->endpoint_config->{event_status_mapping}->{$event->{HistoryType}};
     return unless $map;
     return ( $map, $event->{HistoryType} ) unless ref $map eq 'HASH';
     my $field = $map->{field};

--- a/perllib/Open311/Endpoint/Integration/Uniform.pm
+++ b/perllib/Open311/Endpoint/Integration/Uniform.pm
@@ -8,13 +8,12 @@ use warnings;
 use DateTime::Format::W3CDTF;
 use Digest::MD5 qw(md5_hex);
 use Moo;
-use Path::Tiny;
 use Types::Standard ':all';
 use JSON::MaybeXS;
 
 extends 'Open311::Endpoint';
 with 'Open311::Endpoint::Role::mySociety';
-with 'Role::Config';
+with 'Role::EndpointConfig';
 with 'Role::Logger';
 
 use Integrations::Uniform;
@@ -37,22 +36,22 @@ has '+identifier_types' => (
 
 has service_whitelist => (
     is => 'ro',
-    default => sub { $_[0]->config->{service_whitelist} || {} },
+    default => sub { $_[0]->endpoint_config->{service_whitelist} || {} },
 );
 
 has database => (
     is => 'lazy',
-    default => sub { $_[0]->config->{database} }
+    default => sub { $_[0]->endpoint_config->{database} }
 );
 
 has username => (
     is => 'lazy',
-    default => sub { $_[0]->config->{username} }
+    default => sub { $_[0]->endpoint_config->{username} }
 );
 
 has password => (
     is => 'lazy',
-    default => sub { $_[0]->config->{password} }
+    default => sub { $_[0]->endpoint_config->{password} }
 );
 
 sub logon {

--- a/perllib/Role/EndpointConfig.pm
+++ b/perllib/Role/EndpointConfig.pm
@@ -1,0 +1,34 @@
+# Very similar to Role::Config, but to be used by subclasses of Web::Simple
+# (such as any Open311::Endpoint::Integration::...) as that sets a config
+# attribute
+
+package Role::EndpointConfig;
+
+use Path::Tiny;
+use YAML::XS qw(LoadFile);
+use Moo::Role;
+
+has config_file => (
+    is => 'lazy',
+    coerce => sub { path($_[0]) },
+);
+
+sub _build_config_file {
+    my $self = shift;
+    my $path = path(__FILE__)->parent(3)->realpath->child('conf');
+    $path->child('council-' . $self->jurisdiction_id . '.yml');
+}
+
+has endpoint_config => (
+    is => 'lazy',
+    isa => sub { die "not a hashref" unless ref $_[0] eq 'HASH' },
+);
+
+sub _build_endpoint_config {
+    my $self = shift;
+    return {} if !$self->config_file->is_file && $ENV{TEST_MODE};
+    my $conf = LoadFile($self->config_file);
+    return $conf;
+}
+
+1;

--- a/t/open311/endpoint/bexley_symology.yml
+++ b/t/open311/endpoint/bexley_symology.yml
@@ -1,0 +1,26 @@
+username: FMS
+nsgref_to_action:
+    '123/4567': 'N1'
+    '234/5678': 'S2'
+customer_defaults:
+    CustomerType: "PB"
+category_mapping:
+    AbanVeh:
+        name: 'Abandoned vehicles'
+        parameters:
+            ServiceCode: 'ServiceCode'
+            RequestType: 'ReqType'
+            AnalysisCode1: 'A1'
+            AnalysisCode2: 'A2'
+        questions:
+          - code: 'message'
+            description: 'Please ignore yellow cars'
+            variable: 0
+          - code: 'car_details'
+            description: 'Car details'
+          - code: 'burnt'
+            description: 'Burnt out?'
+            values: [ 'Yes', 'No' ]
+        logic:
+          - rules: [ '$attr.burnt', 'Yes' ]
+            output: { Priority: 'P1' }

--- a/t/open311/endpoint/bexley_uniform.t
+++ b/t/open311/endpoint/bexley_uniform.t
@@ -82,7 +82,7 @@ $integ->mock(config => sub {
 });
 
 my $end = Test::MockModule->new('Open311::Endpoint::Integration::UK::Bexley::Uniform');
-$end->mock(config => sub {
+$end->mock(endpoint_config => sub {
     {
         username => 'FMS',
         service_whitelist => {

--- a/t/open311/endpoint/centralbedfordshire.t
+++ b/t/open311/endpoint/centralbedfordshire.t
@@ -120,7 +120,7 @@ $centralbeds_integ->mock(config => sub {
 });
 
 my $centralbeds_end = Test::MockModule->new('Open311::Endpoint::Integration::UK::CentralBedfordshire');
-$centralbeds_end->mock(config => sub {
+$centralbeds_end->mock(endpoint_config => sub {
     {
         username => 'FMS',
         nsgref_to_action => {},

--- a/t/open311/endpoint/ezytreev.t
+++ b/t/open311/endpoint/ezytreev.t
@@ -77,7 +77,7 @@ $lwp->mock(request => sub {
     }
 });
 
-my $config = {
+my $endpoint_config = {
     endpoint_url => 'http://example.com/',
     username => 'user',
     password => 'pass',
@@ -100,10 +100,10 @@ my $config = {
 };
 
 my $ezytreev_open311_mock = Test::MockModule->new('Open311::Endpoint::Integration::Ezytreev');
-$ezytreev_open311_mock->mock(config => sub { $config });
+$ezytreev_open311_mock->mock(endpoint_config => sub { $endpoint_config });
 
 my $ezytreev_mock = Test::MockModule->new('Integrations::Ezytreev');
-$ezytreev_mock->mock(config => sub { $config });
+$ezytreev_mock->mock(config => sub { $endpoint_config });
 
 use Open311::Endpoint::Integration::Ezytreev;
 

--- a/t/open311/endpoint/uniform.t
+++ b/t/open311/endpoint/uniform.t
@@ -134,7 +134,7 @@ $integ->mock(config => sub {
 });
 
 my $end = Test::MockModule->new('Open311::Endpoint::Integration::Uniform');
-$end->mock(config => sub {
+$end->mock(endpoint_config => sub {
     {
         username => 'FMS',
         service_whitelist => {


### PR DESCRIPTION
This partially reverts commit c55f7eed9. Web::Simple::Application has an attribute called `config`, so we cannot use that in a subclass, as it has already been set. Even if it didn't, I'm not sure anything was actually setting config_filename in these classes to be used.

The test move to use a yml file rather than mock config directly would be enough to catch the first of these, because config was then not set at all when running the test.