### PR TITLE
[Rutland] Pass through Salesforce HTML hint text in attributes

### DIFF
--- a/perllib/Integrations/SalesForce.pm
+++ b/perllib/Integrations/SalesForce.pm
@@ -6,6 +6,7 @@ use LWP::UserAgent;
 
 with 'Role::Config';
 with 'Role::Logger';
+with 'Role::Memcached';
 
 use JSON::MaybeXS;
 
@@ -185,15 +186,26 @@ sub get_updates {
 sub get_services {
     my ($self, $args) = @_;
 
-    my $services = $self->get($self->services_endpoint . '?summary');
+    my $key = "get_services";
+    my $expiry = 300; # cache all these API calls for 5 minutes
+    my $services = $self->memcache->get($key);
 
-    my @services;
-
-    for my $service (@{ $services->{CategoryInformation} }) {
-        push @services, $service;
+    if ($services) {
+        $self->logger->debug("Found memcached entry for $key");
+        return @$services;
     }
 
-    return @services;
+    $self->logger->debug("No memcached entry found for $key. Fetching services from Salesforce");
+
+    $services = [];
+    my $response = $self->get($self->services_endpoint . '?summary');
+    for my $service (@{ $response->{CategoryInformation} }) {
+        push @$services, $service;
+    }
+
+    $self->memcache->set($key, $services, $expiry);
+
+    return @$services;
 }
 
 sub get_service {

--- a/perllib/Open311/Endpoint/Integration/SalesForce.pm
+++ b/perllib/Open311/Endpoint/Integration/SalesForce.pm
@@ -207,6 +207,22 @@ sub service {
     my ($self, $id, $args) = @_;
 
     my $meta = $self->get_integration->get_service($id, $args);
+    my @services = $self->get_integration->get_services($args);
+
+    my %service_lookup = map { $_->{serviceid} => $_ } @services;
+    my $srv = $service_lookup{$id};
+    my $parent;
+    my $hint = '';
+    my $group_hint = '';
+
+    if ($srv) {
+        $parent = $service_lookup{$srv->{parent}};
+        $hint = $srv->{html};
+    }
+
+    if ($parent) {
+        $group_hint = $parent->{html};
+    }
 
     my $service = Open311::Endpoint::Service::UKCouncil::Rutland->new(
         service_name => $meta->{title},
@@ -232,6 +248,25 @@ sub service {
         my $attrib = Open311::Endpoint::Service::Attribute->new(%options);
         push @{ $service->attributes }, $attrib;
     }
+
+    my %options = (
+        required => 0,
+        variable => 0,
+        datatype => 'string',
+        automated => 'server_set',
+    );
+
+    push @{ $service->attributes }, Open311::Endpoint::Service::Attribute->new(
+        code => 'hint',
+        description => $hint,
+        %options,
+    );
+
+    push @{ $service->attributes }, Open311::Endpoint::Service::Attribute->new(
+        code => 'group_hint',
+        description => $group_hint,
+        %options,
+    );
 
     return $service;
 }

--- a/perllib/Open311/Endpoint/Service/UKCouncil/Rutland.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/Rutland.pm
@@ -48,6 +48,8 @@ has internal_attributes => (
       title => 1,
       description => 1,
       closest_address => 1,
+      group_hint => 1,
+      hint => 1,
   } },
 );
 

--- a/t/open311/endpoint/rutland.t
+++ b/t/open311/endpoint/rutland.t
@@ -130,10 +130,10 @@ my %responses = (
         "CategoryInformation": [
             {
                 "serviceid": "a096E000007pbxWQAQ",
-                "parent" : "",
+                "parent" : "a096E000007pbwiQAA",
                 "name_code": "POT",
                 "name": "Fly Tipping",
-                "html" : "",
+                "html" : "<span>This is the category HTML hint</span>",
                 "hasChildren" : "false"
             },
             {
@@ -141,8 +141,8 @@ my %responses = (
                 "parent" : "",
                 "name_code": "RC08",
                 "name": "Street Furniture",
-                "html" : "",
-                "hasChildren" : "false"
+                "html" : "<span>This is the group HTML hint</span>",
+                "hasChildren" : "true"
             },
             {
                 "serviceid" : "a012500000JJ0nBAAT",
@@ -840,16 +840,7 @@ subtest "check fetch service description" => sub {
         metadata => 'true',
         type => "realtime",
         keywords => "",
-        group => ""
-    },
-    {
-        service_code => 'a096E000007pbwiQAA',
-        metadata => 'true',
-        type => "realtime",
-        keywords => "",
-        group => "",
-        service_name => "Street Furniture",
-        description => "Street Furniture"
+        group => "Street Furniture"
     },
     {
         metadata => "true",
@@ -942,6 +933,26 @@ subtest "check fetch service metadata" => sub {
             datatype_description => '',
             order => 5,
             description => "Additional Information",
+          },
+          {
+            variable => 'false',
+            code => "hint",
+            datatype => "string",
+            required => 'false',
+            datatype_description => '',
+            order => 6,
+            description => "<span>This is the category HTML hint</span>",
+            automated => 'server_set',
+          },
+          {
+            variable => 'false',
+            code => "group_hint",
+            datatype => "string",
+            required => 'false',
+            datatype_description => '',
+            order => 7,
+            description => "<span>This is the group HTML hint</span>",
+            automated => 'server_set',
           }
         ]
     }, 'correct json returned';


### PR DESCRIPTION
Rutland's Salesforce now includes an `html` field on categories and groups which Rutland want to display on the FMS front end. This change puts the HTML from Salesforce for both the category and the category's group into the service's attributes so that FMS can pull it out at the other end.

The PR to output this text on FixMyStreet is here: https://github.com/mysociety/fixmystreet/pull/3434.

Part of https://github.com/mysociety/societyworks/issues/2206

## Notes to reviewer

I originally tried doing this with new top-level elements, but that didn't quite feel right and broke lots of tests. So I went with putting it in the attributes in the end, even though it doesn't feel _quite_ right. You can see the code I wrote for that here: https://github.com/mysociety/open311-adapter/compare/rutland-salesforce-groups-support...rutland-salesforce-html-hint-text.

## Notes to merger

- [ ] Merge https://github.com/mysociety/open311-adapter/pull/173 before this PR, as this PR builds on top of that one