### PR TITLE
[Salesforce] Fix update fetching with rich quotes

### DIFF
--- a/bin/get_salesforce_credentials.pl
+++ b/bin/get_salesforce_credentials.pl
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/perllib/Open311/Endpoint/Integration/SalesForce.pm
+++ b/perllib/Open311/Endpoint/Integration/SalesForce.pm
@@ -104,7 +104,7 @@ sub get_service_request_updates {
             $comment = '';
             $digest = md5_hex($update->{Status} . '_' . $update_time);
         } else {
-            $digest = md5_hex($comment);
+            $digest = md5_hex(encode_utf8($comment));
         }
 
         push @updates, Open311::Endpoint::Service::Request::Update::mySociety->new(

--- a/t/open311/endpoint/rutland.t
+++ b/t/open311/endpoint/rutland.t
@@ -773,7 +773,7 @@ subtest "check fetch update with unicode comment" => sub {
     $responses{'GET FixMyStreetUpdates updates'} = '[{
         "Status": "Investigating",
         "id": "a086E000001gcVRQAY",
-        "Comments": "This has ünicöde in"
+        "Comments": "This one’s got ünicöde in"
     }]';
 
     my $res = $endpoint->run_test_request(
@@ -788,9 +788,9 @@ subtest "check fetch update with unicode comment" => sub {
     [ {
         status => 'investigating',
         service_request_id => 'a086E000001gcVRQAY',
-        description => 'This has ünicöde in',
+        description => 'This one’s got ünicöde in',
         updated_datetime => '2014-01-01T11:59:40Z',
-        update_id => 'a086E000001gcVRQAY_d29ca6e6e819a627d2d6e1d64373946e',
+        update_id => 'a086E000001gcVRQAY_03e91e398401ede1c3f242f43825126d',
         media_url => '',
     } ], 'correct json returned';
 };


### PR DESCRIPTION
"’" in fetched update text was causing "Wide character in subroutine entry" errors