### PR TITLE
[Confirm] Remove file locking.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK.pm
+++ b/perllib/Open311/Endpoint/Integration/UK.pm
@@ -116,7 +116,12 @@ sub confirm_upload {
 
             foreach ($dir->children( qr/\.json$/ )) {
                 my $id = $_->basename('.json');
-                my $data = decode_json($_->slurp_utf8);
+                my $data = do {
+                    my $fh = $_->openr_utf8;
+                    local $/;
+                    decode_json(scalar <$fh>);
+                };
+
                 my $success = $integ->upload_enquiry_documents($id, $data);
                 if ($success) {
                     $dir->child($id)->remove_tree; # Files for upload


### PR DESCRIPTION
This data is currently held over NFS and we were seeing stuck flock calls.
These files are not written to, only read or removed, and the script only
runs on one server anyway, it would still have a race condition if run on
more than one even with shared locking.