### PR TITLE
[Confirm] Use ‘datetime’ attribute type for date fields in Confirm

### DIFF
--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -287,6 +287,11 @@ sub NewEnquiry {
         SOAP::Data->name($_ => $value)->type("")
     } keys %enq;
 
+    my $tag_types = {
+        singlevaluelist => 'EnqAttribValueCode',
+        datetime => 'EnqAttribDateValue',
+    };
+
     for my $code (keys %{ $args->{attributes} }) {
         next if grep {$code eq $_} ('easting', 'northing', 'fixmystreet_id', 'closest_address');
         my $value = substr($args->{attributes}->{$code}, 0, 2000);
@@ -296,7 +301,7 @@ sub NewEnquiry {
         # to Confirm results in an error, so just skip over it.
         next if (!$value && $service_types{$code} eq 'singlevaluelist' && !$attributes_required{$code});
 
-        my $tag = $service_types{$code} eq 'singlevaluelist' ? 'EnqAttribValueCode' : 'EnqAttribStringValue';
+        my $tag = $tag_types->{$service_types{$code}} || 'EnqAttribStringValue';
         push @elements, SOAP::Data->name('EnquiryAttribute' => \SOAP::Data->value(
             SOAP::Data->name('EnqAttribTypeCode' => SOAP::Utils::encode_data($code))->type(""),
             SOAP::Data->name($tag => SOAP::Utils::encode_data($value))->type(""),

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -721,6 +721,7 @@ sub _parse_attributes {
     $attribute_types = [ $attribute_types ] if $attribute_types && ref $attribute_types ne 'ARRAY';
     for (@$attribute_types) {
         my $code = $_->{EnqAttribTypeCode};
+        my $flag = $_->{EnqAttribTypeFlag} || '';
 
         my $required = $_->{MandatoryFlag} eq 'true' ? 1 : 0;
         my $desc = $self->attribute_descriptions->{$code} || $_->{EnqAttribTypeName};
@@ -735,7 +736,7 @@ sub _parse_attributes {
                 $_->{EnqAttribValueCode} => $name
             }
         } @{ $enquiry_attributes };
-        my $type = %values ? 'singlevaluelist' : 'string';
+        my $type = $flag eq 'D' ? 'datetime' : %values ? 'singlevaluelist' : 'string';
 
 
         # printf "\n\nXXXXXXXX $code\n\n\n" if $type eq 'singlevaluelist';

--- a/t/open311/endpoint/confirm_attributes.t
+++ b/t/open311/endpoint/confirm_attributes.t
@@ -46,6 +46,7 @@ $open311->mock(perform_request => sub {
                         { EnqAttribTypeCode => 'QUES', },
                         { EnqAttribTypeCode => 'QUES2', },
                         { EnqAttribTypeCode => 'IGN', },
+                        { EnqAttribTypeCode => 'SINC', },
                     ],
                 } ] },
                 { ServiceCode => 'HM', ServiceName => 'Highways', EnquirySubject => [ { SubjectCode => "PHL" } ] },
@@ -61,6 +62,7 @@ $open311->mock(perform_request => sub {
                 { EnqAttribTypeCode => 'QUES2', MandatoryFlag => 'false', EnqAttribTypeName => 'Bad question',
                   EnquiryAttributeValue => [] },
                 { EnqAttribTypeCode => 'IGN', MandatoryFlag => 'false', EnqAttribTypeName => 'Ignored question' },
+                { EnqAttribTypeCode => 'SINC', MandatoryFlag => 'false', EnqAttribTypeName => 'Abandoned since', EnqAttribTypeFlag => 'D' },
             ],
             } }
         };
@@ -207,6 +209,15 @@ subtest "GET wrapped Service List Description" => sub {
       <datatype_description></datatype_description>
       <description>Better question text</description>
       <order>12</order>
+      <required>false</required>
+      <variable>true</variable>
+    </attribute>
+    <attribute>
+      <code>SINC</code>
+      <datatype>datetime</datatype>
+      <datatype_description></datatype_description>
+      <description>Abandoned since</description>
+      <order>13</order>
       <required>false</required>
       <variable>true</variable>
     </attribute>

--- a/t/open311/endpoint/confirm_date.t
+++ b/t/open311/endpoint/confirm_date.t
@@ -1,0 +1,84 @@
+use strict;
+use warnings;
+
+package Open311::Endpoint::Integration::UK::Dummy;
+use Moo;
+extends 'Open311::Endpoint::Integration::Confirm';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'confirm_date';
+    $args{config_data} = '{"service_whitelist":{"Roads":{"HM_PHS":"Small pothole"}}}';
+    return $class->$orig(%args);
+};
+
+package main;
+
+use Test::More;
+use Test::MockModule;
+use JSON::MaybeXS;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+my $open311 = Test::MockModule->new('Integrations::Confirm');
+$open311->mock(config => sub {
+    return { server_timezone => "Europe/London" };
+});
+$open311->mock(perform_request => sub {
+    my ($self, $op) = @_; # Don't care about subsequent ops
+    $op = $$op;
+    if ($op->name && $op->name eq 'GetEnquiryLookups') {
+        return {
+            OperationResponse => { GetEnquiryLookupsResponse => { TypeOfService => [
+                { ServiceCode => 'HM', ServiceName => 'Highways', EnquirySubject => [ {
+                    SubjectCode => "PHS",
+                    SubjectAttribute => [ { EnqAttribTypeCode => 'SINC' } ],
+                } ] },
+            ],
+            EnquiryAttributeType => [
+                { EnqAttribTypeCode => 'SINC', MandatoryFlag => 'false', EnqAttribTypeName => 'Abandoned since', EnqAttribTypeFlag => 'D' },
+            ],
+            } }
+        };
+    }
+    $op = $op->value;
+    if ($op->name eq 'NewEnquiry') {
+        my %req = map { $_->name => $_->value } ${$op->value}->value;
+        my ($code, $value) = ${$req{EnquiryAttribute}}->value;
+        is $code->name, 'EnqAttribTypeCode';
+        is $value->name, 'EnqAttribDateValue';
+        is $code->value, 'SINC';
+        is $value->value, '2021-11-11';
+        return { OperationResponse => { NewEnquiryResponse => { Enquiry => { EnquiryNumber => 2001 } } } };
+    }
+    return {};
+});
+
+my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
+
+subtest "POST OK" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        api_key => 'test',
+        service_code => 'HM_PHS',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the details",
+        'attribute[easting]' => 100,
+        'attribute[northing]' => 100,
+        'attribute[fixmystreet_id]' => 1001,
+        'attribute[title]' => 'Title',
+        'attribute[description]' => 'This is the details',
+        'attribute[report_url]' => 'http://example.com/report/1001',
+        'attribute[SINC]' => '2021-11-11',
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => 2001
+        } ], 'correct json returned';
+};
+
+done_testing;


### PR DESCRIPTION
Needs test for sending enquiries to Confirm. Might need some counterpart on FMS too.