### PR TITLE
[Confirm] Allow _extra on whitelist codes to work and map to same Confirm service/subject

### DIFF
--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -152,6 +152,17 @@ subtest "GET Service List" => sub {
     <service_name>Flooding</service_name>
     <type>realtime</type>
   </service>
+  <service>
+    <description>Different type of flooding</description>
+    <groups>
+      <group>Flooding &amp; Drainage</group>
+    </groups>
+    <keywords></keywords>
+    <metadata>true</metadata>
+    <service_code>ABC_DEF_1</service_code>
+    <service_name>Different type of flooding</service_name>
+    <type>realtime</type>
+  </service>
 </services>
 XML
     is $res->content, $expected

--- a/t/open311/endpoint/confirm.yml
+++ b/t/open311/endpoint/confirm.yml
@@ -7,6 +7,7 @@ default_site_code: 999999
 service_whitelist:
   Flooding & Drainage:
     ABC_DEF: Flooding
+    ABC_DEF_1: Different type of flooding
   Flooding:
     ABC_DEF: Flooding
 reverse_status_mapping:


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/2797 (once config is updated, see below).

Current live config has one issue without this, in that it has two `RM_FLO` but only one gets created.
Adapted config for changes currently inactive in live would be:

```
Trees:
  RM_TREE_1: Dead/diseased tree
  RM_TREE_2: Other tree issue
  RM_TREE_3: Overhanging branch/tree
  RM_TREE_4: Tree roots raising a footpath
  RM_TREE_5: Tree stumps
  SLRM_SLD_tree: Tree blocking a street light
  ITS_SMP_tree: Tree blocking traffic signal/sign
```
