### PR TITLE
[Confirm] Include completion photo in update.

### DIFF
--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -1,5 +1,7 @@
 package Integrations::Confirm;
 
+use v5.14;
+use warnings;
 use SOAP::Lite;
 use Exporter;
 use DateTime::Format::W3CDTF;
@@ -70,6 +72,16 @@ has 'customer_type_code' => (
 has 'server_timezone' => (
     is => 'lazy',
     default => sub { $_[0]->config->{server_timezone} }
+);
+
+has completion_statuses => (
+    is => 'lazy',
+    default => sub { $_[0]->config->{completion_statuses} || [] }
+);
+
+has base_url => (
+    is => 'lazy',
+    default => sub { $_[0]->config->{base_url}  }
 );
 
 has oauth_token => (
@@ -509,20 +521,52 @@ sub upload_enquiry_documents {
         centralDocLinks => [ @photos, @uploads ]
     };
 
-    my $token = $self->oauth_token;
-    return unless $token;
+    $self->web_api_call("/centralEnquiries",
+        Content_Type => 'application/json',
+        Content => encode_json($body))
+        or return;
+    return 1;
+}
+
+sub web_api_call {
+    my ($self, $url, %headers) = @_;
+    my $token = $self->oauth_token or return;
     my ($username, $password, $tenant) = $self->credentials;
-    my $url = $self->config->{web_url} . $tenant . "/centralEnquiries";
-    my $req = POST $url,
-        AccessToken => $token,
-        'Content-Type' => 'application/json',
-        Content => encode_json($body);
-    my $response = $self->ua->request($req);
+    my $full_url = $self->config->{web_url} . $tenant . $url;
+    my $method = $headers{Content} ? 'post' : 'get';
+    my $response = $self->ua->$method($full_url, AccessToken => $token, %headers);
     unless ($response->is_success) {
-        $self->logger->warn("Couldn't post files to Confirm: " . $response->content);
+        $self->logger->warn("Couldn't fetch $url: " . $response->content);
         return;
     };
-    return 1;
+    return $response;
+}
+
+sub json_web_api_call {
+    my ($self, $url, %headers) = @_;
+    $headers{Content_Type} = 'application/json';
+    my $response = $self->web_api_call($url, %headers) or return;
+    return decode_json($response->content);
+}
+
+sub job_id_for_enquiry {
+    my ($self, $enquiry_id) = @_;
+    my $data = $self->json_web_api_call("/enquiries/$enquiry_id");
+    return $data->{primaryJobNumber};
+}
+
+sub documents_for_job {
+    my ($self, $job_id) = @_;
+    my $data = $self->json_web_api_call("/jobs/$job_id");
+    return $data->{documents} || [];
+}
+
+sub get_job_photo {
+    my ($self, $job_id, $photo_id) = @_;
+    my $response = $self->web_api_call("/documents/0/JOB/$job_id/$photo_id") or return;
+    my $type = $response->header('Content-Type') || '';
+    return unless $type =~ m{image/(jpeg|pjpeg|gif|tiff|png)}i;
+    return ( $type, $response->decoded_content );
 }
 
 1;

--- a/perllib/Open311/Endpoint/Integration/UK.pm
+++ b/perllib/Open311/Endpoint/Integration/UK.pm
@@ -3,6 +3,7 @@ package Open311::Endpoint::Integration::UK;
 use Moo;
 extends 'Open311::Endpoint';
 with 'Open311::Endpoint::Role::mySociety';
+with 'Open311::Endpoint::Role::CompletionPhotos';
 
 use Types::Standard ':all';
 use Module::Pluggable

--- a/perllib/Open311/Endpoint/Integration/UK/Lincolnshire.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Lincolnshire.pm
@@ -24,5 +24,11 @@ sub process_service_request_args {
     return $args;
 }
 
+sub photo_filter {
+    my ($self, $doc) = @_;
+    my $filename = $doc->{fileName} || '';
+    my $notes = $doc->{documentNotes} || '';
+    return $filename =~ /jpe?g/i && $notes =~ /after/i;
+}
 
 1;

--- a/perllib/Open311/Endpoint/Role/CompletionPhotos.pm
+++ b/perllib/Open311/Endpoint/Role/CompletionPhotos.pm
@@ -1,0 +1,26 @@
+package Open311::Endpoint::Role::CompletionPhotos;
+
+use Moo::Role;
+no warnings 'illegalproto';
+
+around dispatch_request => sub {
+    my ($orig, $self, @args) = @_;
+    my @dispatch = $self->$orig(@args);
+    return (
+        @dispatch,
+
+        sub (GET + /photo/completion + ?*) {
+            my ($self, $args) = @_;
+            $self->get_completion_photo( $args );
+        },
+    );
+};
+
+sub get_completion_photo {
+    my ($self, $args) = @_;
+    $self->_call('get_completion_photo', $args->{jurisdiction_id}, $args)
+        or [ 400, [ 'Content-type', 'text/plain' ], [ 'Bad request' ] ];
+}
+
+
+1;

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -123,6 +123,10 @@ $open311->mock(perform_request => sub {
           return { OperationResponse => { GetEnquiryStatusChangesResponse => { UpdatedEnquiry => [
               { EnquiryNumber => 2020, EnquiryStatusLog => [ { EnquiryLogNumber => 5, StatusLogNotes => 'Secret status log notes', LogEffectiveTime => '2019-10-23T12:00:00Z', LoggedTime => '2019-10-23T12:00:00Z', EnquiryStatusCode => 'INP' } ] },
           ] } } };
+        } elsif ($req{LoggedTimeFrom} eq '2022-10-23T01:00:00+01:00' && $req{LoggedTimeTo} eq '2022-10-24T01:00:00+01:00') {
+          return { OperationResponse => { GetEnquiryStatusChangesResponse => { UpdatedEnquiry => [
+              { EnquiryNumber => 2020, EnquiryStatusLog => [ { EnquiryLogNumber => 5, StatusLogNotes => 'Secret status log notes', LogEffectiveTime => '2019-10-23T12:00:00Z', LoggedTime => '2019-10-23T12:00:00Z', EnquiryStatusCode => 'FIX' } ] },
+          ] } } };
         } else {
           return { OperationResponse => { GetEnquiryStatusChangesResponse => { UpdatedEnquiry => [
               { EnquiryNumber => 2001, EnquiryStatusLog => [ { EnquiryLogNumber => 3, LogEffectiveTime => '2018-03-01T12:00:00Z', LoggedTime => '2018-03-01T12:00:00Z', EnquiryStatusCode => 'INP' } ] },
@@ -535,6 +539,24 @@ XML
     or diag $res->content;
 };
 
+subtest "fetching of completion photos" => sub {
+    my $lwp = Test::MockModule->new('LWP::UserAgent');
+    $lwp->mock(request => sub {
+        my ($ua, $req) = @_;
+        return HTTP::Response->new(200, 'OK', [], '{"access_token":"123","expires_in":3600}') if $req->uri =~ /oauth\/token/;
+        return HTTP::Response->new(200, 'OK', [], '{"primaryJobNumber":"432"}') if $req->uri =~ /enquiries\/2020/;
+        return HTTP::Response->new(200, 'OK', [], '{"documents":[
+            {"documentNo":1,"fileName":"photo1.jpeg","documentNotes":"Before"},
+            {"documentNo":2,"fileName":"photo2.jpeg","documentNotes":"After"}
+            ]}') if $req->uri =~ /jobs\/432/;
+    });
+    my $res = $endpoint->run_test_request(
+        GET => '/servicerequestupdates.xml?start_date=2022-10-23T00:00:00Z&end_date=2022-10-24T00:00:00Z',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    contains_string $res->content, '<media_url>http://example.com/photo/completion?jurisdiction_id=confirm_dummy&amp;job=432&amp;photo=1</media_url>';
+};
+
 $endpoint = Open311::Endpoint::Integration::UK::DummyPrivate->new;
 
 subtest 'GET reports - private' => sub {
@@ -642,4 +664,5 @@ subtest "StatusLogNotes shouldn't appear in updates" => sub {
     contains_string $res->content, '<update_id>2020_5</update_id>';
     lacks_string $res->content, 'Secret status log notes';
 };
+
 done_testing;

--- a/t/open311/endpoint/confirm.yml
+++ b/t/open311/endpoint/confirm.yml
@@ -13,4 +13,9 @@ service_whitelist:
 reverse_status_mapping:
   DUP: duplicate
   INP: in_progress
+  FIX: fixed
+completion_statuses:
+  - FIX
+base_url: http://example.com/
+web_url: http://example.org/web/api
 cutoff_enquiry_date: 2018-04-12T12:00:00

--- a/t/open311/endpoint/lincolnshire.t
+++ b/t/open311/endpoint/lincolnshire.t
@@ -1,0 +1,78 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::LongString;
+use Test::MockModule;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+use Open311::Endpoint::Integration::UK;
+
+package Integrations::Confirm::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Integrations::Confirm';
+sub _build_config_file { path(__FILE__)->sibling("confirm.yml")->stringify }
+
+package Open311::Endpoint::Integration::UK::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Open311::Endpoint::Integration::UK::Lincolnshire';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{config_file} = path(__FILE__)->sibling("confirm.yml")->stringify;
+    return $class->$orig(%args);
+};
+has integration_class => (is => 'ro', default => 'Integrations::Confirm::Dummy');
+
+package main;
+
+my $open311 = Test::MockModule->new('Integrations::Confirm');
+$open311->mock(perform_request => sub {
+    my ($self, $op) = @_; # Don't care about subsequent ops
+    $op = $$op;
+    $op = $op->value;
+    if ($op->name eq 'GetEnquiryStatusChanges') {
+        my %req = map { $_->name => $_->value } ${$op->value}->value;
+        return { OperationResponse => { GetEnquiryStatusChangesResponse => { UpdatedEnquiry => [
+            { EnquiryNumber => 2020, EnquiryStatusLog => [ { EnquiryLogNumber => 5, LogEffectiveTime => '2022-10-23T12:00:00Z', LoggedTime => '2022-10-23T12:00:00Z', EnquiryStatusCode => 'FIX' } ] },
+        ] } } };
+    }
+    return {};
+});
+
+subtest "looking up of completion photos" => sub {
+    my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
+    my $lwp = Test::MockModule->new('LWP::UserAgent');
+    $lwp->mock(request => sub {
+        my ($ua, $req) = @_;
+        return HTTP::Response->new(200, 'OK', [], '{"access_token":"123","expires_in":3600}') if $req->uri =~ /oauth\/token/;
+        return HTTP::Response->new(200, 'OK', [], '{"primaryJobNumber":"432"}') if $req->uri =~ /enquiries\/2020/;
+        return HTTP::Response->new(200, 'OK', [], '{"documents":[
+            {"documentNo":1,"fileName":"photo1.jpeg","documentNotes":"Before"},
+            {"documentNo":2,"fileName":"photo2.jpeg","documentNotes":"After"}
+            ]}') if $req->uri =~ /jobs\/432/;
+    });
+    my $res = $endpoint->run_test_request(
+        GET => '/servicerequestupdates.xml?start_date=2022-10-23T00:00:00Z&end_date=2022-10-24T00:00:00Z',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    contains_string $res->content, '<media_url>http://example.com/photo/completion?jurisdiction_id=lincolnshire_confirm&amp;job=432&amp;photo=2</media_url>';
+};
+
+subtest 'fetching of completion photos' => sub {
+    my $endpoint = Open311::Endpoint::Integration::UK->new;
+    my $lwp = Test::MockModule->new('LWP::UserAgent');
+    $lwp->mock(request => sub {
+        my ($ua, $req) = @_;
+        return HTTP::Response->new(200, 'OK', [], '{"access_token":"123","expires_in":3600}') if $req->uri =~ /oauth\/token/;
+        return HTTP::Response->new(200, 'OK', [Content_Type => 'image/jpeg'], 'data') if $req->uri =~ /documents\/0/;
+    });
+    my $res = $endpoint->run_test_request(
+        GET => '/photo/completion?jurisdiction_id=lincolnshire_confirm&job=432&photo=2'
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    is $res->content, 'data';
+};
+
+done_testing;


### PR DESCRIPTION
Adds a new ‘completion_statuses’ config key which controls when Confirm should be queried for a job completion photo when fetching Open311 updates.

Changes from when you wrote it: Removed memcached code, removed login token code (oauth works), tidied up API call functions and moved bits round, made Lincolnshire-specific function, added tests.

Have tested locally with both production and development, and appears to work :)