### PR TITLE
Allow any service attribute through by default

### DIFF
--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -292,7 +292,8 @@ sub NewEnquiry {
         datetime => 'EnqAttribDateValue',
     };
 
-    for my $code (keys %{ $args->{attributes} }) {
+    for my $code (map { $_->code } @{ $service->attributes }) {
+        next unless exists $args->{attributes}->{$code};
         next if grep {$code eq $_} ('easting', 'northing', 'fixmystreet_id', 'closest_address');
         my $value = substr($args->{attributes}->{$code}, 0, 2000);
 

--- a/perllib/Integrations/SalesForce.pm
+++ b/perllib/Integrations/SalesForce.pm
@@ -140,7 +140,8 @@ sub post_request {
     };
 
     # add category specific attributes
-    for my $extra (keys %{ $args->{attributes} } ) {
+    for my $extra (map { $_->code } @{ $service->attributes}) {
+        next unless exists $args->{attributes}->{$extra};
         unless (exists $service->internal_attributes->{$extra}) {
             $values->{$extra} = $args->{attributes}->{$extra};
         }

--- a/perllib/Open311/Endpoint.pm
+++ b/perllib/Open311/Endpoint.pm
@@ -459,11 +459,11 @@ sub POST_Service_Request_input_schema {
         $attributes{ $section }{ $key } = $def;
     }
 
-    if ($service->allow_any_attributes) {
-        for my $key (grep { /^attribute\[\w+\]$/ } keys %$args) {
-            $attributes{optional}{$key} = '//str'
-                unless $attributes{required}{$key};
-        }
+    for my $key (grep { /^attribute\[\w+\]$/ } keys %$args) {
+        next if $attributes{optional}{$key} || $attributes{required}{$key};
+
+        $attributes{optional}{$key} = '//str';
+        $self->logger->warn("Unknown attribute: $key") unless $service->allow_any_attributes;
     }
 
     # we have to supply at least one of these, but can supply more

--- a/t/open311/endpoint.t
+++ b/t/open311/endpoint.t
@@ -1,5 +1,7 @@
 use strict; use warnings;
 
+BEGIN { $ENV{TEST_MODE} = 1; }
+
 use Test::More;
 use Test::LongString;
 use Test::MockTime ':all';

--- a/t/open311/endpoint/Endpoint1.pm
+++ b/t/open311/endpoint/Endpoint1.pm
@@ -78,7 +78,6 @@ sub services {
             type => 'realtime',
             keywords => [qw/ bin /],
             group => 'sanitation',
-            allow_any_attributes => 1,
         )
     );
 }

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -101,6 +101,9 @@ $open311->mock(perform_request => sub {
         if ($req{EnquiryReference} == 1002) {
             ok !defined $req{LoggedTime}, 'LoggedTime omitted';
         }
+        if ($req{EnquiryReference} == 1003) {
+            ok !defined $req{EnquiryAttribute}, 'extra "testing" attribute is ignored';
+        }
         return { OperationResponse => { NewEnquiryResponse => { Enquiry => { EnquiryNumber => 2001 } } } };
     } elsif ($op->name eq 'EnquiryUpdate') {
         # Check contents of req here
@@ -330,6 +333,32 @@ subtest "POST OK with logged time omitted" => sub {
         'attribute[title]' => 'Title',
         'attribute[description]' => 'This is the details',
         'attribute[report_url]' => 'http://example.com/report/1001',
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => 2001
+        } ], 'correct json returned';
+};
+
+subtest "POST OK with unrecognised attribute" => sub {
+    my $res = $endpoint2->run_test_request(
+        POST => '/requests.json',
+        api_key => 'test',
+        service_code => 'ABC_DEF',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the details",
+        'attribute[easting]' => 100,
+        'attribute[northing]' => 100,
+        'attribute[fixmystreet_id]' => 1003,
+        'attribute[title]' => 'Title',
+        'attribute[description]' => 'This is the details',
+        'attribute[report_url]' => 'http://example.com/report/1003',
+        'attribute[testing]' => 'This should be ignored',
     );
     ok $res->is_success, 'valid request'
         or diag $res->content;

--- a/t/open311/endpoint/rutland.t
+++ b/t/open311/endpoint/rutland.t
@@ -443,6 +443,49 @@ subtest "create problem with multiple photos" => sub {
 
 };
 
+subtest "create problem with unrecognised attribute" => sub {
+    set_fixed_time('2014-01-01T12:00:00Z');
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        jurisdiction_id => 'rutland',
+        api_key => 'test',
+        service_code => 'POT',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        email => 'test@example.com',
+        description => 'description',
+        lat => '50',
+        long => '0.1',
+        'attribute[description]' => 'description',
+        'attribute[external_id]' => '1',
+        'attribute[title]' => '1',
+        'attribute[testing]' => 'Should be ignored',
+    );
+    ok $res->is_success, 'valid request';
+
+    my $sent = pop @sent;
+    is_deeply decode_json($sent),
+    [{
+        detail__c => "description",
+        description__c => "description",
+        updated_datetime__c => "2014-01-01T12:00:00+0000",
+        status__c => "open",
+        lat__c => 50.0,
+        service_request_id__c => 1,
+        Service_Area__c => "POT",
+        requested_datetime__c => "2014-01-01T12:00:00+0000",
+        requestor_name__c => "Bob Mould",
+        title__c => "1",
+        interface_used__c => "Web interface",
+        long__c => 0.1,
+        contact_name__c => "Bob Mould",
+        contact_email__c => 'test@example.com',
+        agency_sent_datetime__c => "2014-01-01T12:00:00+0000",
+        agency_responsible__c => "Rutland County Council",
+    }] , 'correct json sent';
+};
+
 subtest "check fetch problem" => sub {
     set_fixed_time('2014-01-01T12:00:00Z');
     my $res = $endpoint->run_test_request(


### PR DESCRIPTION
Previously this was only set on the Echo integration (see https://github.com/mysociety/open311-adapter/commit/706644b47883c57e0373ca4e27559cc0088e0c4b), but this is probably a sensible default generally, in the spirit of being liberal with what you receive.

I'm printing out a warning to the logfile if an attribute is unrecognised, but these are suppressed if the service has the allow_any_attributes flag set.

This is a roundabout way of fixing the error that Bucks is getting on staging currently, as that's an issue with the new grass cutting question not being recognised.

The change to `.github/workflows/default.yml` was necessary because calling methods on `$self->logger` fails without a `conf/general.yml` present.