### PR TITLE
Add "for_triage" extended status.

### DIFF
--- a/perllib/Open311/Endpoint/Role/mySociety.pm
+++ b/perllib/Open311/Endpoint/Role/mySociety.pm
@@ -312,6 +312,7 @@ sub learn_additional_types {
             'no_further_action',
             'internal_referral',
             'reopen',
+            'for_triage',
         )
     );
     $schema->learn_type( 'tag:wiki.open311.org,GeoReport_v2:rx/status_extended_upper',
@@ -327,6 +328,7 @@ sub learn_additional_types {
             'NO_FURTHER_ACTION',
             'INTERNAL_REFERRAL',
             'REOPEN',
+            'FOR_TRIAGE',
         )
     );
     $schema->learn_type( 'tag:wiki.open311.org,GeoReport_v2:rx/service_request_update',

--- a/perllib/Open311/Endpoint/Service/Request/Update/mySociety.pm
+++ b/perllib/Open311/Endpoint/Service/Request/Update/mySociety.pm
@@ -19,6 +19,7 @@ has status => (
         'no_further_action',
         'internal_referral',
         'reopen',
+        'for_triage',
     ],
 );
 


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/2819 combined with https://github.com/mysociety/societyworks/issues/2821 - we're going to have a Confirm status code that will set the state at the FMS end to "for triage", which will then display it on the /admin/triage page for recategorisation. So we need open311-adapter to pass this new state (which already exists at the FMS end, but IoW use it on-site, not through a backend) through from Confirm to FMS.