### PR TITLE
[Sutton] Add endpoint.

### DIFF
--- a/conf/council-sutton_echo.yml-example
+++ b/conf/council-sutton_echo.yml-example
@@ -1,0 +1,11 @@
+url: ""
+username: ""
+password: ""
+
+client_reference_prefix: "LBS"
+service_whitelist: {}
+service_to_event_type: {}
+service_id_override: {}
+data_key_open311_map: {}
+default_data_all: {}
+default_data_event_type: {}

--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -21,6 +21,10 @@ has jurisdiction_id => ( is => 'ro' );
 # types behind one service) to event type description
 has service_whitelist => ( is => 'ro' );
 
+# A mapping of service code to service code (used when the
+# incoming service codes don't match that actually in use)
+has service_mapping => ( is => 'ro', default => sub { {} } );
+
 # A mapping of service code and Echo service ID to event type
 # (used for the case of multiple event types behind one service)
 has service_to_event_type => ( is => 'ro', default => sub { {} } );
@@ -181,6 +185,10 @@ sub process_service_request_args {
     my $service = $args->{attributes}{service_id} || '';
     my $uprn = $args->{attributes}{uprn};
     my $client_reference = $self->client_reference($args);
+
+    # Sometimes we need to map our incoming service IDs
+    $service = $self->service_mapping->{$service}
+        if $self->service_mapping->{$service};
 
     # Missed collections have different event types depending
     # on the service

--- a/perllib/Open311/Endpoint/Integration/UK/Sutton.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Sutton.pm
@@ -1,0 +1,27 @@
+package Open311::Endpoint::Integration::UK::Sutton;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::Echo';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'sutton_echo';
+    return $class->$orig(%args);
+};
+
+around check_for_data_value => sub {
+    my ($orig, $class, $name, $args, $request, $parent_name) = @_;
+
+    my $service = $args->{attributes}{service_id} || '';
+
+    return 1 if $name eq 'Container Mix' && ($service eq '2241' || $service eq '2250');
+    return 1 if $name eq 'Paper' && ($service eq '2240' || $service eq '2249');
+    return 1 if $name eq 'Food' && ($service eq '2239' || $service eq '2248');
+    return 1 if $name eq 'Garden' && $service eq '2247';
+    return 1 if $name eq 'Refuse Bag' && $service eq '2242';
+    return 1 if $name eq 'Refuse Bin' && ($service eq '2238' || $service eq '2243');
+
+    return $class->$orig($name, $args, $request, $parent_name);
+};
+
+1;

--- a/t/open311/endpoint/sutton.t
+++ b/t/open311/endpoint/sutton.t
@@ -1,0 +1,152 @@
+package SOAP::Result;
+use Object::Tiny qw(method result);
+
+package Integrations::Echo::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Integrations::Echo';
+sub _build_config_file { path(__FILE__)->sibling("sutton.yml")->stringify }
+
+package Open311::Endpoint::Integration::Echo::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Open311::Endpoint::Integration::UK::Sutton';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'echo_dummy';
+    $args{config_file} = path(__FILE__)->sibling("sutton.yml")->stringify;
+    return $class->$orig(%args);
+};
+has integration_class => (is => 'ro', default => 'Integrations::Echo::Dummy');
+
+package main;
+
+use strict;
+use warnings;
+use utf8;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+use Test::More;
+use Test::MockModule;
+use SOAP::Lite;
+use JSON::MaybeXS;
+
+use_ok 'Open311::Endpoint::Integration::UK::Sutton';
+
+use constant EVENT_TYPE_MISSED => 'missed';
+use constant EVENT_TYPE_SUBSCRIBE => 1638;
+
+my $soap_lite = Test::MockModule->new('SOAP::Lite');
+$soap_lite->mock(call => sub {
+    # This is called when a test below makes a SOAP call, along with the data
+    # to be passed via SOAP to the server. We check the values here, then pass
+    # back a mocked result.
+    my ($cls, @args) = @_;
+    my $method = $args[0]->name;
+    if ($method eq 'PostEvent') {
+        my @params = ${$args[3]->value}->value;
+        my $client_ref = $params[1]->value;
+        my $event_type = $params[3]->value;
+        my $service_id = $params[4]->value;
+        like $client_ref, qr/LBS-200012[345]/;
+        if ($client_ref eq 'LBS-2000124') {
+            is $event_type, 1566;
+            is $service_id, 405;
+            my @data = ${$params[0]->value}->value->value;
+            my @bin = ${$data[0]->value}->value;
+            is $bin[0]->value, 2000;
+            is $bin[1]->value, 1;
+        } elsif ($client_ref eq 'LBS-2000125') {
+            is $event_type, 1568;
+            is $service_id, 408;
+            my @data = ${$params[0]->value}->value->value;
+            my @paper = ${$data[0]->value}->value;
+            is $paper[0]->value, 2002;
+            is $paper[1]->value, 1;
+        }
+        return SOAP::Result->new(result => {
+            EventGuid => '1234',
+        });
+    } elsif ($method eq 'GetEventType') {
+        return SOAP::Result->new(result => {
+            Datatypes => { ExtensibleDatatype => [
+                { Id => 1004, Name => "Container Stuff",
+                    ChildDatatypes => { ExtensibleDatatype => [
+                        { Id => 1005, Name => "Quantity" },
+                        { Id => 1007, Name => "Containers" },
+                    ] },
+                },
+                { Id => 1008, Name => "Notes" },
+                { Id => 2000, Name => "Refuse Bin" },
+                { Id => 2001, Name => "Container Mix" },
+                { Id => 2002, Name => "Paper" },
+            ] },
+        });
+    } else {
+        is $method, 'UNKNOWN';
+    }
+});
+
+use Open311::Endpoint::Integration::Echo::Dummy;
+my $endpoint = Open311::Endpoint::Integration::Echo::Dummy->new;
+
+my @params = (
+    POST => '/requests.json',
+    api_key => 'test',
+    first_name => 'Bob',
+    last_name => 'Mould',
+    description => "This is the details",
+    lat => 51,
+    long => -1,
+    'attribute[uprn]' => 1000001,
+);
+
+subtest "POST subscription request OK" => sub {
+    my $res = $endpoint->run_test_request(@params,
+        service_code => EVENT_TYPE_SUBSCRIBE,
+        'attribute[fixmystreet_id]' => 2000123,
+        'attribute[Subscription_Details_Containers]' => 26, # Garden Bin
+        'attribute[Subscription_Details_Quantity]' => 1,
+        'attribute[Request_Type]' => 1,
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => '1234',
+        } ], 'correct json returned';
+};
+
+subtest "POST missed bin OK" => sub {
+    my $res = $endpoint->run_test_request(@params,
+        service_code => EVENT_TYPE_MISSED,
+        'attribute[fixmystreet_id]' => 2000124,
+        'attribute[service_id]' => 2238,
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => '1234',
+        } ], 'correct json returned';
+};
+
+subtest "POST missed mixed+paper OK" => sub {
+    my $res = $endpoint->run_test_request(@params,
+        service_code => EVENT_TYPE_MISSED,
+        'attribute[fixmystreet_id]' => 2000125,
+        'attribute[service_id]' => 2240,
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => '1234',
+        } ], 'correct json returned';
+};
+
+done_testing;

--- a/t/open311/endpoint/sutton.yml
+++ b/t/open311/endpoint/sutton.yml
@@ -1,0 +1,51 @@
+url: http://sutton.example.org/
+username: username
+password: password
+
+client_reference_prefix: LBS
+
+service_whitelist:
+  missed: 'Report missed collection'
+  1635: 'Request new container'
+  1638: 'Garden Subscription'
+  1569: 'General Enquiry'
+
+service_mapping:
+    2238: 405
+    2242: 405
+    2239: 408
+    2240: 408
+    2241: 408
+    2247: 409
+
+service_id_override:
+  1638: 409
+  1635: 412
+
+service_to_event_type:
+  missed:
+    405: 1566
+    408: 1568
+    409: 1568
+
+data_key_open311_map:
+  First Name: 'first_name'
+  Surname: 'last_name'
+  Email: 'email'
+  Telephone: 'phone'
+
+default_data_all:
+  Resident Requires Feedback: 1
+
+default_data_event_type:
+  # 1566:
+  #   Refuse Bin: 1
+  #   Refuse Bag: 1
+  # 1568:
+  #   Container Mix: 1
+  #   Paper: 1
+  #   Food: 1
+  #   Garden: 1
+  1635:
+    Action: 1 # Deliver
+    Reason: 3 # Change Capacity

--- a/t/open311/endpoint/uk.t
+++ b/t/open311/endpoint/uk.t
@@ -22,6 +22,7 @@ my %config_filenames = (
     'Open311::Endpoint::Integration::UK::Lincolnshire' => 'lincolnshire_confirm',
     'Open311::Endpoint::Integration::UK::Rutland' => 'rutland',
     'Open311::Endpoint::Integration::UK::Shropshire' => 'shropshire_confirm',
+    'Open311::Endpoint::Integration::UK::Sutton' => 'sutton_echo',
     'Open311::Endpoint::Integration::UK::Hampshire' => 'hampshire_confirm',
 );
 


### PR DESCRIPTION
This is an empty Echo endpoint, apart from adding `service_mapping` as the FMS end is using (and passing through to here) Task IDs, not service IDs which we then need to send to Echo; and a little bit of code to set the right booleans in the missed collection events depending on what comes in (this is awaiting confirmation from them but might as well go up as is).