### PR TITLE
[Lincolnshire] Pass customer details through from Confirm

### DIFF
--- a/conf/council-lincolnshire_confirm.yml-example
+++ b/conf/council-lincolnshire_confirm.yml-example
@@ -12,3 +12,4 @@ reverse_status_mapping: {}
 attribute_descriptions: {}
 ignored_attribute_options: []
 default_site_code: ""
+include_private_customer_details: 1

--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -640,10 +640,9 @@ sub json_web_api_call {
     return decode_json($response->content);
 }
 
-sub job_id_for_enquiry {
+sub get_enquiry_json {
     my ($self, $enquiry_id) = @_;
-    my $data = $self->json_web_api_call("/enquiries/$enquiry_id");
-    return $data->{primaryJobNumber};
+    return $self->json_web_api_call("/enquiries/$enquiry_id");
 }
 
 sub documents_for_job {

--- a/perllib/Open311/Endpoint/Integration/AlloyV2.pm
+++ b/perllib/Open311/Endpoint/Integration/AlloyV2.pm
@@ -35,7 +35,7 @@ with 'Role::Logger';
 use Integrations::AlloyV2;
 use Open311::Endpoint::Service::UKCouncil::Alloy;
 use Open311::Endpoint::Service::Attribute;
-use Open311::Endpoint::Service::Request::CanBeNonPublic;
+use Open311::Endpoint::Service::Request::Alloy;
 use Open311::Endpoint::Service::Request::Update::mySociety;
 
 use Path::Tiny;
@@ -47,7 +47,7 @@ has jurisdiction_id => (
 
 has '+request_class' => (
     is => 'ro',
-    default => 'Open311::Endpoint::Service::Request::CanBeNonPublic',
+    default => 'Open311::Endpoint::Service::Request::Alloy',
 );
 
 has '+identifier_types' => (

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -10,7 +10,7 @@ with 'Role::Logger';
 use Open311::Endpoint::Service::UKCouncil::Confirm;
 use Open311::Endpoint::Service::Attribute;
 use Open311::Endpoint::Service::Request::Update::mySociety;
-use Open311::Endpoint::Service::Request::CanBeNonPublic;
+use Open311::Endpoint::Service::Request::Confirm;
 use Integrations::Confirm;
 
 use Path::Tiny;
@@ -411,7 +411,7 @@ sub process_service_request_args {
 
 has '+request_class' => (
     is => 'ro',
-    default => 'Open311::Endpoint::Service::Request::CanBeNonPublic',
+    default => 'Open311::Endpoint::Service::Request::Confirm',
 );
 
 has 'integration_class' => (

--- a/perllib/Open311/Endpoint/Role/mySociety.pm
+++ b/perllib/Open311/Endpoint/Role/mySociety.pm
@@ -395,6 +395,8 @@ sub learn_additional_types {
                 agency_responsible => '//str',
                 service_notice => '//str',
                 non_public => '//str',
+                contact_name => '//str',
+                contact_email => '//str',
             },
         }
     );

--- a/perllib/Open311/Endpoint/Service/Request/Alloy.pm
+++ b/perllib/Open311/Endpoint/Service/Request/Alloy.pm
@@ -1,0 +1,6 @@
+package Open311::Endpoint::Service::Request::Alloy;
+use Moo;
+extends 'Open311::Endpoint::Service::Request::ExtendedStatus';
+with 'Open311::Endpoint::Service::Role::CanBeNonPublic';
+
+1;

--- a/perllib/Open311/Endpoint/Service/Request/Confirm.pm
+++ b/perllib/Open311/Endpoint/Service/Request/Confirm.pm
@@ -1,0 +1,6 @@
+package Open311::Endpoint::Service::Request::Confirm;
+use Moo;
+extends 'Open311::Endpoint::Service::Request::ExtendedStatus';
+with 'Open311::Endpoint::Service::Role::CanBeNonPublic';
+
+1;

--- a/perllib/Open311/Endpoint/Service/Request/Confirm.pm
+++ b/perllib/Open311/Endpoint/Service/Request/Confirm.pm
@@ -3,4 +3,20 @@ use Moo;
 extends 'Open311::Endpoint::Service::Request::ExtendedStatus';
 with 'Open311::Endpoint::Service::Role::CanBeNonPublic';
 
+use Types::Standard ':all';
+
+has '+optional_fields' => (
+    default => sub { [ 'non_public', 'contact_name', 'contact_email' ] },
+);
+
+has contact_name => (
+    is => 'ro',
+    isa => Str,
+);
+
+has contact_email => (
+    is => 'ro',
+    isa => Str,
+);
+
 1;

--- a/perllib/Open311/Endpoint/Service/Role/CanBeNonPublic.pm
+++ b/perllib/Open311/Endpoint/Service/Role/CanBeNonPublic.pm
@@ -1,9 +1,6 @@
-package Open311::Endpoint::Service::Request::CanBeNonPublic;
-use Moo;
-use MooX::HandlesVia;
-extends 'Open311::Endpoint::Service::Request::ExtendedStatus';
+package Open311::Endpoint::Service::Role::CanBeNonPublic;
+use Moo::Role;
 
-use DateTime;
 use Types::Standard ':all';
 
 has 'optional_fields' => (
@@ -17,6 +14,5 @@ has non_public => (
     isa => Str,
     default => 0
 );
-
 
 1;

--- a/t/open311/endpoint/confirm.yml
+++ b/t/open311/endpoint/confirm.yml
@@ -24,3 +24,4 @@ service_enquiry_class_code:
 base_url: http://example.com/
 web_url: http://example.org/web/api
 cutoff_enquiry_date: 2018-04-12T12:00:00
+include_private_customer_details: 1


### PR DESCRIPTION
Lincolnshire want reports created in Confirm to be associated with the correct user so that the user can receive updates from FixMyStreet.

This change get the customer name and email from Confirm and passes them to FMS in the GET Service Requests call.

FixMyStreet change that uses this data: https://github.com/mysociety/fixmystreet/pull/4110

Part of https://github.com/mysociety/societyworks/issues/3079

## Notes to deployer

- [x] Add `include_private_customer_details: 1` to the Lincs Confirm config before deploying this change