### PR TITLE
[Bartec] Handle extended data values without ‘ - ’ correctly

### DIFF
--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -547,8 +547,13 @@ sub get_extended_data {
                 if ( $field->{ValueList} ) {
                     my $values = $self->_coerce_to_array( $field->{ValueList}, 'Values' );
                     my @answers = map {
+                        # reset $1 to a known empty value. For some reason
+                        # on macOS $1 might be 'darwin' at this point, and if
+                        # the Value regex doesn't match that value will be
+                        # carried through.
+                        "" =~ /(.*)/;
                         $_->{Value} =~ /(.+) -/;
-                        [ $_->{Value}, $1 ];
+                        [ $_->{Value}, $1 || $_->{Value} ];
                     } @$values;
                     $conf->{values} = \@answers;
                 }

--- a/t/open311/endpoint/bartec.t
+++ b/t/open311/endpoint/bartec.t
@@ -409,6 +409,10 @@ subtest "check fetch service" => sub {
                     key => 'Lots - W01',
                 },
                 {
+                    name => 'Plenty',
+                    key => 'Plenty',
+                },
+                {
                     name => 'Some',
                     key => 'Some - W02',
                 }

--- a/t/open311/endpoint/xml/bartec/extended_definitions.xml
+++ b/t/open311/endpoint/xml/bartec/extended_definitions.xml
@@ -103,6 +103,11 @@
                   <Sequence>20</Sequence>
                   <Value>Some - W02</Value>
                 </Values>
+                <Values>
+                  <ID>2461</ID>
+                  <Sequence>30</Sequence>
+                  <Value>Plenty</Value>
+                </Values>
                 <RecordStamp>
                   <AddedBy>proj_amiller</AddedBy>
                   <DateAdded>2019-05-03T16:22:47.22</DateAdded>


### PR DESCRIPTION
Not all Bartec values follow the pattern the regex was looking for. As a result the `$1` might have been empty causing a schema validation error when trying to fetch the service metadata.

Additionally, on macOS the `$1` value was sometimes `darwin`, oddly, which meant that all values had that as their label if the regex didn’t match.