### PR TITLE
[Symology] Add request default config.

### DIFF
--- a/perllib/Integrations/Symology.pm
+++ b/perllib/Integrations/Symology.pm
@@ -208,7 +208,7 @@ sub SOAP::Serializer::as_RequestSend {
         RecordedTime => $dt->strftime('%H:%M:%S'),
         UserName => $value->{UserName},
         RequestType => $value->{RequestType},
-        Priority => $value->{Priority} || 'N',
+        Priority => $value->{Priority} // 'N',
         AnalysisCode1 => $value->{AnalysisCode1},
         AnalysisCode2 => $value->{AnalysisCode2},
         Location => $value->{Location} || '',

--- a/perllib/Open311/Endpoint/Integration/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/Symology.pm
@@ -50,6 +50,11 @@ has customer_defaults => (
     default => sub { $_[0]->endpoint_config->{customer_defaults} }
 );
 
+has request_defaults => (
+    is => 'lazy',
+    default => sub { $_[0]->endpoint_config->{request_defaults} }
+);
+
 has external_id_prefix => (
     is => 'lazy',
     default => sub { $_[0]->endpoint_config->{external_id_prefix} || "" }
@@ -106,6 +111,7 @@ sub process_service_request_args {
     die "Could not find category mapping for $service_code\n" unless $codes;
 
     my $request = {
+        %{$self->request_defaults || {}},
         Description => $args->{description},
         UserName => $self->username,
         %{$codes->{parameters}},

--- a/t/open311/endpoint/brent.t
+++ b/t/open311/endpoint/brent.t
@@ -80,7 +80,7 @@ $soap_lite->mock(call => sub {
         my $photo_desc = "\n\n[ This report contains a photo, see: http://example.org/photo/1.jpeg ]";
         my $burnt = 'No';
         is $request[REPORT_DESC]->value, "This is the details$photo_desc\n\nBurnt out?: $burnt\n\nCar details: Details";
-        is $request[REPORT_PRIORITY]->value, "N";
+        is $request[REPORT_PRIORITY]->value, "P";
         return {
             StatusCode => 0,
             StatusMessage => 'Success',

--- a/t/open311/endpoint/brent_symology.yml
+++ b/t/open311/endpoint/brent_symology.yml
@@ -1,5 +1,7 @@
 services:
 username: FMS
+request_defaults:
+    Priority: "P"
 customer_defaults:
     CustomerType: "PB"
 category_mapping:


### PR DESCRIPTION
This will let someone specify e.g. a default fallback Priority.
Could simplify the existing Central Beds config as well with this.