### PR TITLE
Add Passthrough integration

### DIFF
--- a/conf/council-www.bromley.gov.uk.yml-example
+++ b/conf/council-www.bromley.gov.uk.yml-example
@@ -1,0 +1,2 @@
+endpoint: https://localhost:4000/
+api_key: 123

--- a/perllib/Open311/Endpoint/Integration/Multi.pm
+++ b/perllib/Open311/Endpoint/Integration/Multi.pm
@@ -80,7 +80,7 @@ sub _map_with_new_id {
 }
 
 sub _map_from_new_id {
-    my ($self, $code) = @_;
+    my ($self, $code, $type) = @_;
 
     my $names = join('|', grep { $_ ne $self->integration_without_prefix } map { $_->{name} } @{$_[0]->integrations});
     my ($integration, $service_code) = $code =~ /^($names)-(.*)/;
@@ -116,7 +116,7 @@ prefixed again.
 sub service {
     my ($self, $service_id, $args) = @_;
     # Extract integration from service code and pass to correct child
-    my ($integration, $service_code) = $self->_map_from_new_id($service_id);
+    my ($integration, $service_code) = $self->_map_from_new_id($service_id, 'service');
     my $service = $self->_call('service', $integration, $service_code, $args);
     ($service) = $self->_map_with_new_id(service_code => [$integration, $service]);
     return $service;
@@ -133,7 +133,7 @@ parent will be calling service() again.
 sub post_service_request {
     my ($self, $service, $args) = @_;
     # Extract integration from service code and set up to pass to child
-    my ($integration, $service_code) = $self->_map_from_new_id($service->service_code);
+    my ($integration, $service_code) = $self->_map_from_new_id($service->service_code, 'service');
     my $integration_args = { %$args, service_code => $service_code };
     # Strip off the integration part of the service code from the service object
     my $integration_service = (ref $service)->new(%$service, service_code => $service_code);
@@ -148,8 +148,8 @@ sub post_service_request_update {
 
     # Cobrand needs to send the service_code through with updates
     # (see Bexley's open311_munge_update_params in FMS for example)
-    my ($integration, $service_code) = $self->_map_from_new_id($args->{service_code});
-    my ($integration2, $service_request_id) = $self->_map_from_new_id($args->{service_request_id});
+    my ($integration, $service_code) = $self->_map_from_new_id($args->{service_code}, 'service');
+    my ($integration2, $service_request_id) = $self->_map_from_new_id($args->{service_request_id}, 'request');
     die "$integration did not equal $integration2\n" if $integration ne $integration2;
 
     my $integration_args = {

--- a/perllib/Open311/Endpoint/Integration/Passthrough.pm
+++ b/perllib/Open311/Endpoint/Integration/Passthrough.pm
@@ -42,6 +42,15 @@ has jurisdiction_id => ( is => 'ro' );
 has endpoint => ( is => 'ro' );
 has api_key => ( is => 'ro' );
 
+=head2 ignore_services
+
+Provide a list of service codes that should be ignored and not passed back from
+the proxied backend.
+
+=cut
+
+has ignore_services => ( is => 'ro', => default => sub { [] } );
+
 has updates_url => ( is => 'ro', default => 'servicerequestupdates.xml' );
 
 sub service_request_content {
@@ -117,7 +126,9 @@ sub services {
     my ($self, $args) = @_;
     my $xml = $self->_request(GET => 'services.xml');
     my @services;
+    my %ignore = map { $_ => 1 } @{$self->ignore_services};
     foreach (@{$xml->{service}}) {
+        next if $ignore{$_->{service_code}};
         my $service = Open311::Endpoint::Service->new(%$_);
         if ($_->{metadata} eq 'true') {
             # An empty one is enough to get the metadata true passed out

--- a/perllib/Open311/Endpoint/Integration/Passthrough.pm
+++ b/perllib/Open311/Endpoint/Integration/Passthrough.pm
@@ -1,0 +1,248 @@
+=head1 NAME
+
+Open311::Endpoint::Integration::Passthrough - a transparent proxy integration
+
+=head1 SUMMARY
+
+This integration passes the data on that it receives directly. This is to allow
+a third party Open311 server to sit alongside open311-adapter integrations
+within a Multi service. Validation will be performed on the data coming back.
+
+=head1 DESCRIPTION
+
+=cut
+
+package Open311::Endpoint::Integration::Passthrough;
+
+use Moo;
+extends 'Open311::Endpoint';
+with 'Open311::Endpoint::Role::mySociety';
+with 'Open311::Endpoint::Role::ConfigFile';
+with 'Role::Memcached';
+
+use DateTime::Format::W3CDTF;
+use LWP::UserAgent;
+use URI;
+use XML::Simple qw(:strict);
+use Open311::Endpoint::Service;
+use Open311::Endpoint::Service::Attribute;
+use Open311::Endpoint::Service::Request;
+use Open311::Endpoint::Service::Request::ExtendedStatus;
+use Open311::Endpoint::Service::Request::Update::mySociety;
+
+=head2 configuration
+
+To use this integration, subclass it and provide a C<jurisdiction_id> in the
+subclass's C<BUILDARGS>. This will then be used to look up a configuration file
+which should contain an C<endpoint> and an C<api_key>.
+
+=cut
+
+has jurisdiction_id => ( is => 'ro' );
+has endpoint => ( is => 'ro' );
+has api_key => ( is => 'ro' );
+
+has updates_url => ( is => 'ro', default => 'servicerequestupdates.xml' );
+
+sub service_request_content {
+    '/open311/service_request_extended'
+}
+
+# This isn't called xml because the root Endpoint class has that attribute
+has pt_xml => (
+    is => 'lazy',
+    default => sub {
+        my $group_tags = {
+            services => 'service',
+            attributes => 'attribute',
+            values => 'value',
+            service_requests => 'request',
+            errors => 'error',
+            service_request_updates => 'request_update',
+            groups => 'group',
+        };
+        XML::Simple->new(
+            SuppressEmpty => 1,
+            KeyAttr => [],
+            ForceArray => [ values %$group_tags ],
+            GroupTags => $group_tags,
+        );
+    },
+);
+
+has ua => (
+    is => 'lazy',
+    default => sub {
+        LWP::UserAgent->new();
+    },
+);
+
+has date_parser => (
+    is => 'lazy',
+    default => sub { DateTime::Format::W3CDTF->new },
+);
+
+=head2 _request
+
+Requests are made to the endpoint, and returned data parsed as XML. POST
+requests include the api_key. An error in the returned data will cause
+the function to die.
+
+=cut
+
+sub _request {
+    my ($self, $method, $url, $params) = @_;
+    $url = URI->new($self->endpoint . $url);
+    my $resp;
+    if ($method eq 'POST') {
+        $params->{api_key} = $self->api_key;
+        $resp = $self->ua->post($url, $params);
+    } else {
+        $url->query_form(%$params);
+        $resp = $self->ua->get($url);
+    }
+    my $content = $resp->decoded_content;
+    my $xml = $self->pt_xml->XMLin(\$content);
+    die $xml->{error}[0]->{description} . "\n" if $xml->{error};
+    return $xml;
+}
+
+=head2 services
+
+Transparently passed through to the backend to fetch a list of services.
+
+=cut
+
+sub services {
+    my ($self, $args) = @_;
+    my $xml = $self->_request(GET => 'services.xml');
+    my @services;
+    foreach (@{$xml->{service}}) {
+        my $service = Open311::Endpoint::Service->new(%$_);
+        if ($_->{metadata} eq 'true') {
+            # An empty one is enough to get the metadata true passed out
+            my $attribute = Open311::Endpoint::Service::Attribute->new;
+            push @{$service->attributes}, $attribute;
+        }
+        push @services, $service;
+    }
+    return @services;
+}
+
+=head2 service
+
+Transparently passed through to the backend to fetch a service.
+
+=cut
+
+sub service {
+    my ($self, $service_id, $args) = @_;
+    my $data = $self->memcache->get("service/$service_id");
+    return $data if $data;
+    my $xml = $self->_request(GET => "services/$service_id.xml");
+    my $service = Open311::Endpoint::Service->new( service_code => $service_id );
+    foreach (@{$xml->{attributes}}) {
+        $_->{required} = $_->{required} eq 'true' ? 1 : 0;
+        $_->{variable} = $_->{variable} eq 'true' ? 1 : 0;
+        # Need to maintain the order
+        $_->{values_sorted} = [ map { $_->{key} } @{$_->{values}} ];
+        $_->{values} = { map { $_->{key} => $_->{name} } @{$_->{values}} };
+        my $attribute = Open311::Endpoint::Service::Attribute->new(%$_);
+        push @{ $service->attributes }, $attribute;
+    }
+    $self->memcache->set("service/$service_id", $service, time() + 60);
+    return $service;
+}
+
+=head2 post_service_request
+
+Resets the attributes to be in the format they were received, then passes
+through to the backend to post a service request.
+
+=cut
+
+sub post_service_request {
+    my ($self, $service, $args) = @_;
+
+    _strip_args($args);
+    my $xml = $self->_request(POST => "requests.xml", $args);
+    my $id = $xml->{request}[0]{service_request_id};
+    my $result = Open311::Endpoint::Service::Request->new(service_request_id => $id);
+    return $result;
+}
+
+=head2 post_service_request_update
+
+Resets the attributes to be in the format they were received, then passes
+through to the backend to post a service request update.
+
+=cut
+
+sub post_service_request_update {
+    my ($self, $args) = @_;
+
+    _strip_args($args);
+    my $xml = $self->_request(POST => $self->updates_url, $args);
+    my $id = $xml->{request_update}[0]{update_id};
+    my $result = Open311::Endpoint::Service::Request::Update::mySociety->new(
+        update_id => $id,
+        status => lc $args->{status},
+    );
+    return $result;
+}
+
+sub _strip_args {
+    my $args = shift;
+    # Yes, just reversing what has just been done
+    foreach my $k (keys %{$args->{attributes}}) {
+        $args->{"attribute[$k]"} = $args->{attributes}{$k};
+    }
+    delete $args->{attributes};
+}
+
+=head2 get_service_request_updates
+
+Fetches a list of updates from the backend.
+
+=cut
+
+sub get_service_request_updates {
+    my ($self, $args) = @_;
+    my $xml = $self->_request(GET => $self->updates_url, $args);
+    my @updates;
+    foreach (@{$xml->{request_update}}) {
+        $_->{status} = lc $_->{status};
+        $_->{updated_datetime} = $self->date_parser->parse_datetime($_->{updated_datetime});
+        $_->{description} ||= "";
+        my $update = Open311::Endpoint::Service::Request::Update::mySociety->new(%$_);
+        push @updates, $update;
+    }
+    return @updates;
+}
+
+=head2 get_service_requests
+
+Fetches a list of requests from the backend.
+
+=cut
+
+sub get_service_requests {
+    my ($self, $args) = @_;
+    my $xml = $self->_request(GET => "requests.xml", $args);
+    my @requests;
+    foreach (@{$xml->{request}}) {
+        $_->{status} = lc $_->{status};
+        $_->{updated_datetime} = $self->date_parser->parse_datetime($_->{updated_datetime});
+        $_->{requested_datetime} = $self->date_parser->parse_datetime($_->{requested_datetime});
+        $_->{latlong} = [ delete $_->{lat}, delete $_->{long} ];
+        $_->{service} = Open311::Endpoint::Service->new(
+            service_name => delete $_->{service_name},
+            service_code => delete $_->{service_code},
+        );
+        my $request = Open311::Endpoint::Service::Request::ExtendedStatus->new(%$_);
+        push @requests, $request;
+    }
+    return @requests;
+}
+
+1;

--- a/perllib/Open311/Endpoint/Integration/UK/Bromley.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bromley.pm
@@ -1,34 +1,40 @@
+=head1 NAME
+
+Open311::Endpoint::Integration::UK::Bromley - Bromley integration set-up
+
+=head1 SYNOPSIS
+
+Bromley will have multiple backends, so is set up as a subclass
+of the Multi integration.
+
+=head1 DESCRIPTION
+
+=cut
+
 package Open311::Endpoint::Integration::UK::Bromley;
 
-use DateTime;
 use Moo;
-extends 'Open311::Endpoint::Integration::Echo';
+extends 'Open311::Endpoint::Integration::Multi';
 
-around BUILDARGS => sub {
-    my ($orig, $class, %args) = @_;
-    $args{jurisdiction_id} = 'bromley_echo';
-    return $class->$orig(%args);
-};
+use Module::Pluggable
+    search_path => ['Open311::Endpoint::Integration::UK::Bromley'],
+    instantiate => 'new';
 
-around process_service_request_args => sub {
-    my ($orig, $class, $args) = @_;
-    my $request = $class->$orig($args);
-    # Assisted collection
-    if ($request->{event_type} == 2149) {
-        my $date = DateTime->today(time_zone => "Europe/London");
-        if ($args->{service_code} eq "2149-add") {
-            $args->{attributes}{"Assisted_Action"} = 1;
-            $args->{attributes}{"Assisted_Start_Date"} = $date->strftime("%d/%m/%Y");
-            $args->{attributes}{"Assisted_End_Date"} = "01/01/2050";
-            $date->add(years => 2);
-            $args->{attributes}{"Review_Date"} = $date->strftime("%d/%m/%Y");
-        } elsif ($args->{service_code} eq "2149-remove") {
-            $args->{attributes}{"Assisted_Action"} = 2;
-            $args->{attributes}{"Assisted_End_Date"} = $date->strftime("%d/%m/%Y");
-        }
-    }
-    return $request;
-};
+has jurisdiction_id => (
+    is => 'ro',
+    default => 'bromley',
+);
 
-1;
+=pod
 
+Bromley was previously only an Echo backend in open311-adapter, so we
+maintain its categories/IDs without any backend prefix.
+
+=cut
+
+has integration_without_prefix => (
+    is => 'ro',
+    default => 'Echo',
+);
+
+__PACKAGE__->run_if_script;

--- a/perllib/Open311/Endpoint/Integration/UK/Bromley.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bromley.pm
@@ -27,14 +27,41 @@ has jurisdiction_id => (
 
 =pod
 
-Bromley was previously only an Echo backend in open311-adapter, so we
-maintain its categories/IDs without any backend prefix.
+Bromley's two endpoints do not overlap in IDs (one integer, one GUID) or
+service codes, so there is no need to prefix them. This code overrides the
+default Multi code to not change anything, and cope accordingly.
 
 =cut
 
-has integration_without_prefix => (
-    is => 'ro',
-    default => 'Echo',
-);
+sub _map_with_new_id {
+    my ($self, $attributes, @results) = @_;
+    @results = map {
+        my ($name, $result) = @$_;
+        $result;
+    } @results;
+    return @results;
+}
+
+my $guid_regex = qr/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+sub _map_from_new_id {
+    my ($self, $code, $type) = @_;
+
+    my $integration;
+    if ($type eq 'request') {
+        if ($code =~ /^\d+$/) {
+            $integration = 'Passthrough';
+        } elsif ($code =~ /$guid_regex/) {
+            $integration = 'Echo';
+        }
+    } elsif ($type eq 'service') {
+        if ($code =~ /^\d+/ || $code eq 'missed') {
+            $integration = 'Echo';
+        } else {
+            $integration = 'Passthrough';
+        }
+    }
+    return ($integration, $code);
+}
 
 __PACKAGE__->run_if_script;

--- a/perllib/Open311/Endpoint/Integration/UK/Bromley/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bromley/Echo.pm
@@ -1,0 +1,54 @@
+=head1 NAME
+
+Open311::Endpoint::Integration::UK::Bromley::Echo - Bromley-specific Echo backend configuration
+
+=head1 SYNOPSIS
+
+Bromley specifics for its Echo backend
+
+=head1 DESCRIPTION
+
+=cut
+
+package Open311::Endpoint::Integration::UK::Bromley::Echo;
+
+use DateTime;
+use Moo;
+extends 'Open311::Endpoint::Integration::Echo';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'bromley_echo';
+    return $class->$orig(%args);
+};
+
+=head2 process_service_request_args
+
+If we are sending an assisted collection event, we need to set some special
+parameters. When adding an assisted collection, we set the action and
+start/end/review dates; when removing, we set the actino and end date.
+
+=cut
+
+around process_service_request_args => sub {
+    my ($orig, $class, $args) = @_;
+    my $request = $class->$orig($args);
+    # Assisted collection
+    if ($request->{event_type} == 2149) {
+        my $date = DateTime->today(time_zone => "Europe/London");
+        if ($args->{service_code} eq "2149-add") {
+            $args->{attributes}{"Assisted_Action"} = 1;
+            $args->{attributes}{"Assisted_Start_Date"} = $date->strftime("%d/%m/%Y");
+            $args->{attributes}{"Assisted_End_Date"} = "01/01/2050";
+            $date->add(years => 2);
+            $args->{attributes}{"Review_Date"} = $date->strftime("%d/%m/%Y");
+        } elsif ($args->{service_code} eq "2149-remove") {
+            $args->{attributes}{"Assisted_Action"} = 2;
+            $args->{attributes}{"Assisted_End_Date"} = $date->strftime("%d/%m/%Y");
+        }
+    }
+    return $request;
+};
+
+1;
+

--- a/perllib/Open311/Endpoint/Integration/UK/Bromley/Passthrough.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bromley/Passthrough.pm
@@ -1,0 +1,27 @@
+=head1 NAME
+
+Open311::Endpoint::Integration::UK::Bromley::Passthrough - Bromley Passthrough backend
+
+=head1 SUMMARY
+
+This is the Bromley-specific Passthrough integration. It is a standard
+Open311 server apart from it uses a different endpoint for updates.
+
+=head1 DESCRIPTION
+
+=cut
+
+package Open311::Endpoint::Integration::UK::Bromley::Passthrough;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::Passthrough';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'www.bromley.gov.uk';
+    return $class->$orig(%args);
+};
+
+has '+updates_url' => ( default => 'update.xml' );
+
+1;

--- a/perllib/Open311/Endpoint/Role/ConfigFile.pm
+++ b/perllib/Open311/Endpoint/Role/ConfigFile.pm
@@ -5,6 +5,11 @@ use Carp 'croak';
 use YAML::XS qw(LoadFile Load);
 use Types::Standard qw( Maybe Str );
 
+has config_filename => (
+    is => 'ro',
+    default => '',
+);
+
 has config_file => (
     is => 'ro',
     isa => Maybe[Str],
@@ -16,7 +21,8 @@ around BUILDARGS => sub {
     my %args = @_;
 
     die unless $args{jurisdiction_id}; # Must have one by here
-    $args{config_file} //= path(__FILE__)->parent(5)->realpath->child("conf/council-$args{jurisdiction_id}.yml")->stringify;
+    my $file = $args{config_filename} || "council-$args{jurisdiction_id}.yml";
+    $args{config_file} //= path(__FILE__)->parent(5)->realpath->child("conf/$file")->stringify;
 
     if (my $config_data = $args{config_data}) {
         my $config = Load($config_data) or croak "Couldn't load config from string";

--- a/perllib/Open311/Endpoint/Role/mySociety.pm
+++ b/perllib/Open311/Endpoint/Role/mySociety.pm
@@ -172,19 +172,28 @@ sub POST_Service_Request_Update_input_schema {
             account_id => '//str',
             service_request_id_ext => '//num',
             public_anonymity_required => Open311::Endpoint::Schema->enum('//str', 'TRUE', 'FALSE'),
+            email_alerts_requested => Open311::Endpoint::Schema->enum('//str', 'TRUE', 'FALSE'),
             service_code => $self->get_identifier_type('service_code'),
         }
     };
 
+    my $jurisdiction = $args->{jurisdiction_id} || '';
+
+    # Bromley has a different update_id key than elsewhere
+    if ($jurisdiction eq 'bromley') {
+        $attributes->{required}{update_id_ext} = $self->get_identifier_type('update_id');
+        delete $attributes->{required}{update_id};
+    }
+
     # Allow attributes through for Oxfordshire XXX
-    if (($args->{jurisdiction_id} || '') eq 'oxfordshire') {
+    if ($jurisdiction eq 'oxfordshire') {
         for my $key (grep { /^attribute\[\w+\]$/ } keys %$args) {
             $attributes->{optional}{$key} = '//str';
         }
     }
 
     # Allow nsg_ref through for Bexley XXX
-    if (($args->{jurisdiction_id} || '') eq 'bexley') {
+    if ($jurisdiction eq 'bexley') {
         if ($args->{'nsg_ref'}) {
 	        $attributes->{optional}{'nsg_ref'} = '//str';
         }

--- a/t/open311/endpoint/bromley.t
+++ b/t/open311/endpoint/bromley.t
@@ -1,0 +1,68 @@
+# Override the original to provide a config_file
+package Open311::Endpoint::Integration::UK::Bromley::Echo;
+use Path::Tiny;
+use Moo;
+extends 'Open311::Endpoint::Integration::Echo';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'bromley_dummy';
+    $args{config_file} = path(__FILE__)->sibling("echo.yml")->stringify;
+    return $class->$orig(%args);
+};
+
+package main;
+
+use strict;
+use warnings;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+use Test::More;
+use Test::MockModule;
+use JSON::MaybeXS;
+
+use_ok 'Open311::Endpoint::Integration::UK::Bromley';
+
+my $endpoint = Open311::Endpoint::Integration::UK::Bromley->new;
+
+subtest "Get service definition with no prefix" => sub {
+    my $res = $endpoint->run_test_request( GET => '/services/2104.json' );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    is_deeply decode_json($res->content), {
+          'service_code' => '2104',
+          'attributes' => [
+            {
+              'variable' => 'true',
+              'datatype_description' => '',
+              'datatype' => 'string',
+              'automated' => 'hidden_field',
+              'code' => 'uprn',
+              'description' => 'UPRN reference',
+              'order' => 1,
+              'required' => 'false'
+            },
+            {
+              'order' => 2,
+              'code' => 'service_id',
+              'description' => 'Service ID',
+              'datatype_description' => '',
+              'datatype' => 'string',
+              'automated' => 'server_set',
+              'required' => 'false',
+              'variable' => 'true'
+            },
+            {
+              'required' => 'true',
+              'datatype_description' => '',
+              'datatype' => 'string',
+              'automated' => 'server_set',
+              'variable' => 'false',
+              'order' => 3,
+              'code' => 'fixmystreet_id',
+              'description' => 'external system ID'
+            }
+          ]
+        }, 'correct json returned';
+};
+
+done_testing;

--- a/t/open311/endpoint/bromley.t
+++ b/t/open311/endpoint/bromley.t
@@ -10,6 +10,16 @@ around BUILDARGS => sub {
     return $class->$orig(%args);
 };
 
+package Open311::Endpoint::Integration::UK::Bromley::Passthrough;
+use Moo;
+extends 'Open311::Endpoint::Integration::Passthrough';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'passthrough_dummy';
+    $args{config_data} = "endpoint: URL/\napi_key: 123";
+    return $class->$orig(%args);
+};
+
 package main;
 
 use strict;
@@ -63,6 +73,39 @@ subtest "Get service definition with no prefix" => sub {
             }
           ]
         }, 'correct json returned';
+};
+
+my $expected_update_post = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_request_updates>
+  <request_update>
+    <update_id>2002</update_id>
+  </request_update>
+</service_request_updates>
+XML
+my $lwp = Test::MockModule->new('LWP::UserAgent');
+$lwp->mock(request => sub {
+    my ($ua, $req) = @_;
+    return HTTP::Response->new(200, 'OK', [], $expected_update_post);
+});
+
+subtest 'POST update' => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/servicerequestupdates.xml',
+        jurisdiction_id => 'bromley',
+        service_code => 'WINTER_SNOW',
+        api_key => 'test',
+        service_request_id => 1001,
+        update_id_ext => 123,
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => 'Update here',
+        status => 'OPEN',
+        updated_datetime => '2016-09-01T15:00:00Z',
+        media_url => 'http://example.org/',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    is $res->content, $expected_update_post, 'xml string ok' or diag $res->content;
 };
 
 done_testing;

--- a/t/open311/endpoint/bromley_echo.t
+++ b/t/open311/endpoint/bromley_echo.t
@@ -10,7 +10,7 @@ sub _build_config_file { path(__FILE__)->sibling("echo.yml")->stringify }
 package Open311::Endpoint::Integration::UK::Bromley::Dummy;
 use Path::Tiny;
 use Moo;
-extends 'Open311::Endpoint::Integration::UK::Bromley';
+extends 'Open311::Endpoint::Integration::UK::Bromley::Echo';
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
     $args{jurisdiction_id} = 'bromley_dummy';

--- a/t/open311/endpoint/passthrough.t
+++ b/t/open311/endpoint/passthrough.t
@@ -1,0 +1,250 @@
+package Open311::Endpoint::Integration::UK::Dummy;
+use Moo;
+extends 'Open311::Endpoint::Integration::Passthrough';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'passthrough_dummy';
+    $args{config_filename} = "dummy"; # For Role::Memcached
+    $args{config_data} = "endpoint: URL/\napi_key: 123";
+    return $class->$orig(%args);
+};
+
+package main;
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::LongString;
+use Test::MockModule;
+use Test::Output;
+use Test::Warn;
+
+use JSON::MaybeXS;
+use Path::Tiny;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+my $expected_services = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<services>
+  <service>
+    <description>Flooding</description>
+    <groups>
+      <group>Flooding</group>
+      <group>Flooding &amp; Drainage</group>
+    </groups>
+    <keywords></keywords>
+    <metadata>true</metadata>
+    <service_code>ABC_DEF</service_code>
+    <service_name>Flooding</service_name>
+    <type>realtime</type>
+  </service>
+  <service>
+    <description>Different type of flooding</description>
+    <groups>
+      <group>Flooding &amp; Drainage</group>
+    </groups>
+    <keywords></keywords>
+    <metadata>true</metadata>
+    <service_code>ABC_DEF_1</service_code>
+    <service_name>Different type of flooding</service_name>
+    <type>realtime</type>
+  </service>
+</services>
+XML
+
+my $expected_defn = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_definition>
+  <attributes>
+    <attribute>
+      <automated>server_set</automated>
+      <code>easting</code>
+      <datatype>number</datatype>
+      <datatype_description></datatype_description>
+      <description>easting</description>
+      <order>1</order>
+      <required>true</required>
+      <variable>false</variable>
+    </attribute>
+    <attribute>
+      <automated>server_set</automated>
+      <code>northing</code>
+      <datatype>number</datatype>
+      <datatype_description></datatype_description>
+      <description>northing</description>
+      <order>2</order>
+      <required>true</required>
+      <variable>false</variable>
+    </attribute>
+    <attribute>
+      <automated>server_set</automated>
+      <code>fixmystreet_id</code>
+      <datatype>string</datatype>
+      <datatype_description></datatype_description>
+      <description>external system ID</description>
+      <order>3</order>
+      <required>true</required>
+      <variable>false</variable>
+    </attribute>
+  </attributes>
+  <service_code>ABC_DEF</service_code>
+</service_definition>
+XML
+
+my $expected_request_post = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_requests>
+  <request>
+    <service_request_id>2001</service_request_id>
+  </request>
+</service_requests>
+XML
+
+my $expected_update_post = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_request_updates>
+  <request_update>
+    <update_id>2002</update_id>
+  </request_update>
+</service_request_updates>
+XML
+
+my $expected_updates = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_request_updates>
+  <request_update>
+    <description></description>
+    <external_status_code>INP</external_status_code>
+    <media_url></media_url>
+    <service_request_id>2001</service_request_id>
+    <status>in_progress</status>
+    <update_id>2001_3</update_id>
+    <updated_datetime>2018-03-01T12:00:00Z</updated_datetime>
+  </request_update>
+  <request_update>
+    <description></description>
+    <external_status_code>INP</external_status_code>
+    <media_url></media_url>
+    <service_request_id>2002</service_request_id>
+    <status>in_progress</status>
+    <update_id>2002_1</update_id>
+    <updated_datetime>2018-03-01T13:00:00Z</updated_datetime>
+  </request_update>
+  <request_update>
+    <description></description>
+    <external_status_code>DUP</external_status_code>
+    <media_url></media_url>
+    <service_request_id>2002</service_request_id>
+    <status>duplicate</status>
+    <update_id>2002_2</update_id>
+    <updated_datetime>2018-03-01T13:30:00Z</updated_datetime>
+  </request_update>
+</service_request_updates>
+XML
+
+my $expected_requests = <<XML;
+<?xml version="1.0" encoding="utf-8"?>
+<service_requests>
+  <request>
+    <address></address>
+    <address_id></address_id>
+    <description>this is a report from confirm</description>
+    <lat>100</lat>
+    <long>100</long>
+    <media_url></media_url>
+    <requested_datetime>2018-04-17T13:34:56+01:00</requested_datetime>
+    <service_code>ABC_DEF</service_code>
+    <service_name>Flooding</service_name>
+    <service_request_id>2003</service_request_id>
+    <status>in_progress</status>
+    <updated_datetime>2018-04-17T13:34:56+01:00</updated_datetime>
+    <zipcode></zipcode>
+  </request>
+</service_requests>
+XML
+
+my $lwp = Test::MockModule->new('LWP::UserAgent');
+$lwp->mock(request => sub {
+    my ($ua, $req) = @_;
+    return HTTP::Response->new(200, 'OK', [], $expected_services) if $req->uri =~ /services\.xml/;
+    return HTTP::Response->new(200, 'OK', [], $expected_defn) if $req->uri =~ /services\/ABC_DEF\.xml/;
+    return HTTP::Response->new(200, 'OK', [], $expected_updates) if $req->method eq 'GET' && $req->uri =~ /servicerequestupdates\.xml/;
+    return HTTP::Response->new(200, 'OK', [], $expected_requests) if $req->method eq 'GET' && $req->uri =~ /requests\.xml/;
+    return HTTP::Response->new(200, 'OK', [], $expected_request_post) if $req->method eq 'POST' && $req->uri =~ /requests\.xml/;
+    return HTTP::Response->new(200, 'OK', [], $expected_update_post) if $req->method eq 'POST' && $req->uri =~ /servicerequestupdates\.xml/;
+});
+
+my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
+
+subtest "GET Service List" => sub {
+    my $res = $endpoint->run_test_request( GET => '/services.xml' );
+    ok $res->is_success, 'xml success';
+    is $res->content, $expected_services or diag $res->content;
+};
+
+subtest "GET Service List Description" => sub {
+    my $res = $endpoint->run_test_request( GET => '/services/ABC_DEF.xml' );
+    ok $res->is_success, 'xml success';
+    is $res->content, $expected_defn or diag $res->content;
+};
+
+subtest "POST OK" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        api_key => 'test',
+        service_code => 'ABC_DEF',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the details",
+        'attribute[easting]' => 100,
+        'attribute[northing]' => 100,
+        'attribute[fixmystreet_id]' => 1001,
+        'attribute[title]' => 'Title',
+        'attribute[description]' => 'This is the details',
+        'attribute[report_url]' => 'http://example.com/report/1001',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => 2001
+        } ], 'correct json returned';
+};
+
+subtest 'POST update' => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/servicerequestupdates.xml',
+        api_key => 'test',
+        service_request_id => 1001,
+        update_id => 123,
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => 'Update here',
+        status => 'OPEN',
+        updated_datetime => '2016-09-01T15:00:00Z',
+        media_url => 'http://example.org/',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    is_string $res->content, $expected_update_post, 'xml string ok' or diag $res->content;
+};
+
+subtest 'GET update' => sub {
+    my $res = $endpoint->run_test_request(
+        GET => '/servicerequestupdates.xml?start_date=2018-01-01T00:00:00Z&end_date=2018-02-01T00:00:00Z',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    is_string $res->content, $expected_updates, 'xml string ok' or diag $res->content;
+};
+
+subtest 'GET reports' => sub {
+    my $res = $endpoint->run_test_request(
+        GET => '/requests.xml?jurisdiction_id=confirm_dummy&start_date=2018-04-17T00:00:00Z&end_date=2018-04-18T00:00:00Z',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+    is_string $res->content, $expected_requests, 'xml string ok' or diag $res->content;
+};
+
+done_testing;
+

--- a/t/open311/endpoint/uk.t
+++ b/t/open311/endpoint/uk.t
@@ -7,7 +7,6 @@ BEGIN { $ENV{TEST_MODE} = 1; }
 
 test_multi(0, 'Open311::Endpoint::Integration::UK',
     'Open311::Endpoint::Integration::UK::BANES' => 'banes_confirm',
-    'Open311::Endpoint::Integration::UK::Bromley' => 'bromley_echo',
     'Open311::Endpoint::Integration::UK::Buckinghamshire' => 'buckinghamshire_confirm',
     'Open311::Endpoint::Integration::UK::Camden' => 'camden_symology',
     'Open311::Endpoint::Integration::UK::CentralBedfordshire' => 'centralbedfordshire_symology',
@@ -33,6 +32,11 @@ test_multi(1, 'Open311::Endpoint::Integration::UK::Bexley',
 test_multi(1, 'Open311::Endpoint::Integration::UK::Brent',
     'Open311::Endpoint::Integration::UK::Brent::Symology' => 'brent_symology',
     'Open311::Endpoint::Integration::UK::Brent::Echo' => 'brent_echo',
+);
+
+test_multi(0, 'Open311::Endpoint::Integration::UK::Bromley',
+    'Open311::Endpoint::Integration::UK::Bromley::Echo' => 'bromley_echo',
+    #'Open311::Endpoint::Integration::UK::Bromley::Passthrough' => 'www.bromley.gov.uk',
 );
 
 test_multi(1, 'Open311::Endpoint::Integration::UK::Peterborough',


### PR DESCRIPTION
This will pass the data it receives through to an external Open311 endpoint, and pass what it receives back (validating as it does).
Along with this, move Bromley to a Multi backend with Echo and Passthrough children.
This is so we can move from FMS only talking directly to Bromley's system to going via open311-adapter, without having to have a bunch of devolved contacts at the FMS end. `ignore_services` is so we can ignore the Bromley services that are moving to Echo (I'm sure they'll remove them for testing soon anyway, but thought might as well have this for now).

Needs POD documentation.