### PR TITLE
[Echo] Initial changes for FMS reporting

### DIFF
--- a/conf/council-bromley_echo.yml-example
+++ b/conf/council-bromley_echo.yml-example
@@ -3,6 +3,7 @@ username: ""
 password: ""
 
 service_whitelist: {}
+waste_services: []
 service_to_event_type: {}
 service_id_override: {}
 data_key_open311_map: {}

--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -118,18 +118,46 @@ sub extensible_data {
 sub PostEvent {
     my ($self, $args) = @_;
 
-    my $uprn = ixhash(
-        Key => 'Uprn',
-        Type => 'PointAddress',
-        Value => [
-            # Must be a string, not a long
-            { 'msArray:anyType' => SOAP::Data->value($args->{uprn})->type('string') },
-        ],
-    );
-    my $source = ixhash(
-        EventObjectType => 'Source',
-        ObjectRef => $uprn,
-    );
+    my $source;
+    if ($args->{uprn}) {
+        my $uprn = ixhash(
+            Key => 'Uprn',
+            Type => 'PointAddress',
+            Value => [
+                # Must be a string, not a long
+                { 'msArray:anyType' => SOAP::Data->value($args->{uprn})->type('string') },
+            ],
+        );
+        $source = ixhash(
+            EventObjectType => 'Source',
+            ObjectRef => $uprn,
+        );
+    } elsif ($args->{usrn}) {
+        my $usrn = ixhash(
+            Key => 'Usrn',
+            Type => 'Street',
+            Value => [
+                # Must be a string, not a long
+                { 'msArray:anyType' => SOAP::Data->value($args->{usrn})->type('string') },
+            ],
+        );
+        $source = ixhash(
+            EventObjectType => 'Source',
+            ObjectRef => $usrn,
+            Location => ixhash(
+                Latitude => $args->{lat},
+                Longitude => $args->{long},
+            ),
+        );
+    } else {
+        $source = ixhash(
+            EventObjectType => 'Source',
+            Location => ixhash(
+                Latitude => $args->{lat},
+                Longitude => $args->{long},
+            ),
+        );
+    }
     my $data = ixhash(
         $args->{data} ? (Data => extensible_data($args->{data})) : (),
         ClientReference => $args->{client_reference},

--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -21,6 +21,9 @@ has jurisdiction_id => ( is => 'ro' );
 # types behind one service) to event type description
 has service_whitelist => ( is => 'ro' );
 
+# A list of which service codes are waste services
+has waste_services => ( is => 'ro', default => sub { [] } );
+
 # A mapping of service code to service code (used when the
 # incoming service codes don't match that actually in use)
 has service_mapping => ( is => 'ro', default => sub { {} } );
@@ -51,6 +54,7 @@ sub services {
     my $self = shift;
 
     my $services = $self->service_whitelist;
+    my %waste_services = map { $_ => 1 } @{$self->waste_services};
     my @services = map {
         my $id = $_;
         my $name = $services->{$_};
@@ -58,7 +62,10 @@ sub services {
             service_name => $name,
             service_code => $_,
             description => $name,
-            group => 'Waste',
+            $waste_services{$_} ? (
+                group => 'Waste',
+                keywords => ['waste_only']
+            ) : (),
             allow_any_attributes => 1,
         );
         $service;

--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -231,6 +231,9 @@ sub process_service_request_args {
         event_type => $event_type,
         service => $service,
         uprn => $uprn,
+        usrn => $args->{attributes}{usrn},
+        lat => $args->{lat},
+        long => $args->{long},
         client_reference => $client_reference,
         data => [],
     };

--- a/t/open311/endpoint/echo.t
+++ b/t/open311/endpoint/echo.t
@@ -237,7 +237,7 @@ subtest "GET services" => sub {
 
     is_deeply decode_json($res->content), [
    {
-      "keywords" => "",
+      "keywords" => "waste_only",
       "service_name" => "Request new container",
       "service_code" => EVENT_TYPE_REQUEST,
       "metadata" => "true",
@@ -246,7 +246,7 @@ subtest "GET services" => sub {
       "group" => "Waste"
    },
    {
-      "keywords" => "",
+      "keywords" => "waste_only",
       "service_name" => "Garden Subscription",
       "service_code" => EVENT_TYPE_SUBSCRIBE,
       "metadata" => "true",
@@ -256,7 +256,7 @@ subtest "GET services" => sub {
    },
    {
       "description" => "Gate not closed",
-      "group" => "Waste",
+      "group" => "",
       "metadata" => "true",
       "type" => "realtime",
       "service_code" => "2118",
@@ -267,7 +267,7 @@ subtest "GET services" => sub {
       "service_name" => "Waste spillage",
       "service_code" => "2119",
       "keywords" => "",
-      "group" => "Waste",
+      "group" => "",
       "description" => "Waste spillage",
       "metadata" => "true",
       "type" => "realtime"
@@ -277,7 +277,7 @@ subtest "GET services" => sub {
       "service_code" => EVENT_TYPE_ENQUIRY,
       "keywords" => "",
       "description" => "General Enquiry",
-      "group" => "Waste",
+      "group" => "",
       "type" => "realtime",
       "metadata" => "true"
    },
@@ -286,7 +286,7 @@ subtest "GET services" => sub {
       "service_code" => "2149-add",
       "keywords" => "",
       "description" => "Assisted collection add",
-      "group" => "Waste",
+      "group" => "",
       "type" => "realtime",
       "metadata" => "true"
    },
@@ -295,7 +295,7 @@ subtest "GET services" => sub {
       "service_code" => "2149-remove",
       "keywords" => "",
       "description" => "Assisted collection remove",
-      "group" => "Waste",
+      "group" => "",
       "type" => "realtime",
       "metadata" => "true"
    },
@@ -304,7 +304,7 @@ subtest "GET services" => sub {
       "service_code" => "missed",
       "keywords" => "",
       "description" => "Report missed collection",
-      "group" => "Waste",
+      "group" => "",
       "type" => "realtime",
       "metadata" => "true"
    },

--- a/t/open311/endpoint/echo.t
+++ b/t/open311/endpoint/echo.t
@@ -300,6 +300,24 @@ subtest "GET services" => sub {
       "metadata" => "true"
    },
    {
+      "service_name" => "Flytipping",
+      "service_code" => "2135",
+      "keywords" => "",
+      "description" => "Flytipping",
+      "groups" => ["Highways", "Superhighways"],
+      "type" => "realtime",
+      "metadata" => "true"
+   },
+   {
+      "service_name" => "Flyposting",
+      "service_code" => "2136",
+      "keywords" => "",
+      "description" => "Flyposting",
+      "groups" => ["Highways"],
+      "type" => "realtime",
+      "metadata" => "true"
+   },
+   {
       "service_name" => "Report missed collection",
       "service_code" => "missed",
       "keywords" => "",

--- a/t/open311/endpoint/echo.yml
+++ b/t/open311/endpoint/echo.yml
@@ -11,6 +11,11 @@ service_whitelist:
   2148: 'General Enquiry'
   2149-add: 'Assisted collection add'
   2149-remove: 'Assisted collection remove'
+  Highways:
+    2135: Flytipping
+    2136: Flyposting
+  Superhighways:
+    2135: Flytipping
 
 waste_services:
   - 2104

--- a/t/open311/endpoint/echo.yml
+++ b/t/open311/endpoint/echo.yml
@@ -12,6 +12,10 @@ service_whitelist:
   2149-add: 'Assisted collection add'
   2149-remove: 'Assisted collection remove'
 
+waste_services:
+  - 2104
+  - 2106
+
 service_to_event_type:
   missed:
     531: 2095


### PR DESCRIPTION
This lets us specify which Echo servers are waste and which aren't (for group/type), lets us have category grouping (wasn't needed for Waste), and lets us report without a UPRN (I’ve used USRN for Bromley, docs imply it should work only with lat/long but it did not for me).