### PR TITLE
[Oxfordshire][Open311] Finer control for jobs with parent defects updating FMS

### DIFF
--- a/perllib/Open311/Endpoint/Integration/AlloyV2.pm
+++ b/perllib/Open311/Endpoint/Integration/AlloyV2.pm
@@ -716,7 +716,7 @@ sub _get_defect_updates_resource {
 
         # we don't care about linked defects until they have been scheduled
         my $status = $self->defect_status($attributes);
-        next if $linked_defect && ( $status eq 'open' || $status eq 'investigating' );
+        next if $self->_skip_job_update($linked_defect, $status);
 
         my @version_ids = $self->get_versions_of_resource($update->{itemId});
         foreach my $date (@version_ids) {
@@ -760,6 +760,12 @@ sub _get_defect_updates_resource {
     }
 
     return @updates;
+}
+
+sub _skip_job_update {
+    my ($self, $linked_defect, $status) = @_;
+
+    return $linked_defect && ( $status eq 'open' || $status eq 'investigating' );
 }
 
 =head2 get_service_requests

--- a/perllib/Open311/Endpoint/Integration/UK/Oxfordshire/AlloyV2.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Oxfordshire/AlloyV2.pm
@@ -94,4 +94,12 @@ sub is_ignored_category {
     return 1 if $status eq 'open';
 }
 
+# Oxfordshire don't want any job updates to be sent when there is a parent defect
+# The parent defect's status is the only change that matters
+sub _skip_job_update {
+    my ($self, $linked_defect) = @_;
+
+    return $linked_defect;
+}
+
 1;


### PR DESCRIPTION
Issue with Oxfordshire having jobs within Alloy updating FMS statuses when the job has a parent defect.

They only want the status on FMS to be updated when the parent status is updated, which is what they want to be reflected to the citizen.

This adds finer control over which type of jobs with parent defects should be skipped over by respective councils.

Maintains the status quo for all except Oxford.

https://mysocietysupport.freshdesk.com/a/tickets/2668