### PR TITLE
[Camden] Send photo URLs to field in Symology

### DIFF
--- a/perllib/Integrations/Symology.pm
+++ b/perllib/Integrations/Symology.pm
@@ -187,12 +187,17 @@ sub current_date {
 sub SOAP::Serializer::as_ArrayOfAdditionalFieldSend {
     my ($self, $value, $name, $type, $attr) = @_;
 
-    my $v = [
-          [ FieldLine => 17, ValueType => 1, DataValue => $value ],
-    ];
+    # Allow individual integrations to provide their own values here, otherwise
+    # assume it's a simple value for the customer type field.
+    unless (ref $value eq 'ARRAY') {
+        $value = [
+            [ FieldLine => 17, ValueType => 1, DataValue => $value ],
+        ];
+    }
+
     my $elem = \SOAP::Data
-        ->name('AdditionalFieldSend' => map { [ make_soap_structure(@$_) ] } @$v)
-        ->attr({'xsi:type' => 'AdditionalFieldSend'});
+        ->name('tns:AdditionalFieldSend' => map { [ make_soap_structure(@$_) ] } @$value)
+        ->attr({'xsi:type' => 'tns:AdditionalFieldSend'});
     return [$name, {'xsi:type' => $type, %$attr}, $elem];
 }
 

--- a/perllib/Open311/Endpoint/Integration/UK/Camden.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Camden.pm
@@ -15,4 +15,26 @@ has jurisdiction_id => (
 # Updates from FMS should always have a GN11 code, meaning "Customer called"
 sub event_action_event_type { 'NOTE' }
 
+=head2 process_service_request_args
+
+Camden's Symology has got a field for a photo URL, so we we send the first
+photo URL to that field when creating a report.
+
+=cut
+
+sub process_service_request_args {
+    my $self = shift;
+
+    my @args = $self->SUPER::process_service_request_args(@_);
+
+    # Send the first photo to the appropriate field in Symology
+    if ( my $photo_url = $_[0]->{media_url}->[0] ) {
+        $args[2] = [
+            [ FieldLine => 10, ValueType => 8, DataValue => $photo_url ],
+        ];
+    }
+
+    return @args;
+}
+
 1;

--- a/t/open311/endpoint/camden.t
+++ b/t/open311/endpoint/camden.t
@@ -36,6 +36,9 @@ use constant {
     REPORT_NEXTACTION => 15,
     UPDATE_REPORT_ID => 123,
     UPDATE_REPORT_ID_CLOSING => 234,
+    FIELDS_FIELDLINE => 0,
+    FIELDS_VALUETYPE => 1,
+    FIELDS_VALUE => 2,
 };
 
 my $soap_lite = Test::MockModule->new('SOAP::Lite');
@@ -46,12 +49,16 @@ $soap_lite->mock(call => sub {
     my ($cls, @args) = @_;
     if ($args[0] eq 'SendRequestAdditionalGroup') {
         my @request = ${$args[2]->value}->value;
+        my @fields = ${$args[4]->value}->value;
         is $request[REPORT_NSGREF]->value, NSGREF;
         is $request[REPORT_NEXTACTION]->value, undef;
         is $request[REPORT_NORTHING]->value, NORTHING;
         is $request[REPORT_EASTING]->value, EASTING;
         my $photo_desc = "\n\n[ This report contains a photo, see: http://example.org/photo/1.jpeg ]";
         is $request[REPORT_DESC]->value, "This is the details$photo_desc\n\nWhat is the issue?: Pothole in the road";
+        is $fields[0][FIELDS_FIELDLINE]->value, 10;
+        is $fields[0][FIELDS_VALUETYPE]->value, 8;
+        is $fields[0][FIELDS_VALUE]->value, "http://example.org/photo/1.jpeg";
         return {
             StatusCode => 0,
             StatusMessage => 'Success',


### PR DESCRIPTION
This field has been configured to accept FixMyStreet photo URLs and display them in the Symology interface.

This is largely based on the work @davea did in https://github.com/mysociety/open311-adapter/pull/190.

Fixes https://github.com/mysociety/societyworks/issues/3492