### PR TITLE
[Symology] Remove local XML files more than two days old

### DIFF
--- a/bin/symology/cleanup_files
+++ b/bin/symology/cleanup_files
@@ -7,10 +7,10 @@ set -eu
 source /data/mysociety/shlib/deployfns
 
 read_conf "$(dirname "$0")/../../conf/council-centralbedfordshire_symology.yml"
-find $OPTION_updates_sftp__out -iname '*.CSV' -ctime 2 -delete
+find $OPTION_updates_sftp__out -iname '*.CSV' -ctime +1 -delete
 
 read_conf "$(dirname "$0")/../../conf/council-camden_symology.yml"
-find $OPTION_updates_sftp__out -iname '*.XML' -ctime 2 -delete
+find $OPTION_updates_sftp__out -iname '*.XML' -ctime +1 -delete
 
 read_conf "$(dirname "$0")/../../conf/council-brent_symology.yml"
-find $OPTION_updates_sftp__out -iname '*.XML' -ctime 2 -delete
+find $OPTION_updates_sftp__out -iname '*.XML' -ctime +1 -delete


### PR DESCRIPTION
This code was searching for files with ctime exactly two days ago, instead of two-or-more days ago.

The reason the code uses `-ctime +1` instead of `-ctime +2` is documented on the find(1) man page:

> When find figures out how many 24-hour periods ago the file was last accessed, any fractional part is ignored, so to match `-atime +1`, a file has to have been accessed at least two days ago.

(`-ctime` has the same behaviour as `-atime`)