### PR TITLE
[Symology] Don't overwrite existing files retrieved from SFTP

### DIFF
--- a/bin/symology/fetch_files
+++ b/bin/symology/fetch_files
@@ -19,7 +19,7 @@ for COBRAND in $@; do
     export SSHPASS=$OPTION_updates_sftp__password
     echo "get $OPTION_updates_sftp__dir data" | sshpass -e sftp -oBatchMode=no -r -b - $OPTION_updates_sftp__username@$OPTION_updates_sftp__host >/dev/null
     if ls -A1q "data" | grep -q .; then
-        mv data/* $OPTION_updates_sftp__out
+        mv -n data/* $OPTION_updates_sftp__out
     fi
 
 done


### PR DESCRIPTION
When moving the files retrieved from SFTP to their destination tell `mv` to skip any files that already exist.

This should fix the cleanup script, which currently isn't removing files because they're getting updated every time they're pulled.