### PR TITLE
[Echo][Brent] Adds extra mandatory fields for missed collection

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/Brent/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Brent/Echo.pm
@@ -9,4 +9,29 @@ around BUILDARGS => sub {
     return $class->$orig(%args);
 };
 
+around process_service_request_args => sub {
+    my ($orig, $class, $args) = @_;
+    my $request = $class->$orig($args);
+
+    # Missed collection
+    if ($request->{event_type} == 2891) {
+        my $service_id = $args->{attributes}{service_id};
+        if ($service_id == 262 || $service_id == 267 || $service_id == 263 || $service_id == 264) {
+            $args->{attributes}{"Refuse_BIN"} = 1;
+            $args->{attributes}{"Refuse_BAG"} = 1;
+        } elsif ($service_id == 265 || $service_id == 266 || $service_id == 268 || $service_id == 269) {
+            $args->{attributes}{"Mixed_Dry_Recycling_BIN"} = 1;
+            $args->{attributes}{"Mixed_Dry_Recyling_BOX"} = 1;
+        } elsif ($service_id == 316 || $service_id == 271) {
+            $args->{attributes}{"Food_CADDY"} = 1;
+            $args->{attributes}{"Food_BIN"} = 1;
+        } elsif ($service_id == 317) {
+            $args->{attributes}{"Garden_BIN"} = 1;
+            $args->{attributes}{"Garden_BAG"} = 1;
+        }
+    }
+
+    return $request;
+};
+
 1;

--- a/perllib/Open311/Endpoint/Integration/UK/Brent/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Brent/Echo.pm
@@ -29,6 +29,11 @@ around process_service_request_args => sub {
             $args->{attributes}{"Garden_BIN"} = 1;
             $args->{attributes}{"Garden_BAG"} = 1;
         }
+    } elsif ($request->{event_type} == 1159) {
+        if ($args->{attributes}{Paid_Collection_Container_Type} == 2) {
+            $args->{attributes}{"Bio_Sacks"} = 1;
+            $args->{attributes}{Paid_Collection_Container_Quantity} = 9; # Bags
+        }
     }
 
     return $request;

--- a/t/open311/endpoint/brent_echo.yml
+++ b/t/open311/endpoint/brent_echo.yml
@@ -6,11 +6,13 @@ service_whitelist:
   935: 'Non-offensive graffiti'
   943: Fly-posting
   2891: 'Report missed collection'
+  1159: Garden subscription
 
 service_to_event_type: {}
 
 waste_services:
  - 2891
+ - 1159
 
 service_id_override:
   935: 277
@@ -24,6 +26,8 @@ data_key_open311_map:
 data_key_attribute_map:
   Exact Location: title
   Notes: description
+  1159:
+    Payment Code: PaymentCode
 
 default_data_all:
   Source: 2

--- a/t/open311/endpoint/brent_echo.yml
+++ b/t/open311/endpoint/brent_echo.yml
@@ -5,8 +5,12 @@ password: "pw"
 service_whitelist:
   935: 'Non-offensive graffiti'
   943: Fly-posting
+  2891: 'Report missed collection'
 
 service_to_event_type: {}
+
+waste_services:
+ - 2891
 
 service_id_override:
   935: 277


### PR DESCRIPTION
Missed collections must check mandatory fields. Currently we can't see how to differentiate between bins and bags so check both fields for any missed collection although only one field is mandatory.

Relates to Brent WW go-live: Missed collection events https://3.basecamp.com/4020879/buckets/28996137/todolists/5888021261