### PR TITLE
[Alloy] Sleep between reconstruct calls

### DIFF
--- a/perllib/Open311/Endpoint/Integration/AlloyV2.pm
+++ b/perllib/Open311/Endpoint/Integration/AlloyV2.pm
@@ -600,7 +600,9 @@ sub _get_inspection_updates {
             }
 
             my $resource = try {
-                $self->alloy->api_call(call => "item-log/item/$update->{itemId}/reconstruct", body => { date => $date });
+                my $r = $self->alloy->api_call(call => "item-log/item/$update->{itemId}/reconstruct", body => { date => $date });
+                sleep 1 unless $ENV{TEST_MODE};
+                return $r;
             };
             next unless $resource && ref $resource eq 'HASH'; # Should always be, but some test calls
 
@@ -754,7 +756,9 @@ sub _get_defect_updates_resource {
             next unless $update_dt >= $start_time && $update_dt <= $end_time;
 
             my $resource = try {
-                $self->alloy->api_call(call => "item-log/item/$update->{itemId}/reconstruct", body => { date => $date });
+                my $r = $self->alloy->api_call(call => "item-log/item/$update->{itemId}/reconstruct", body => { date => $date });
+                sleep 1 unless $ENV{TEST_MODE};
+                return $r;
             };
             next unless $resource && ref $resource eq 'HASH'; # Should always be, but some test calls
 

--- a/t/open311/endpoint/json/alloyv2/northumberland_defects_query_response.json
+++ b/t/open311/endpoint/json/alloyv2/northumberland_defects_query_response.json
@@ -26,6 +26,10 @@
                     "value": "Defect 1"
                 },
                 {
+                    "attributeCode": "attributes_tasksStatus",
+                    "value": [ "5c8bdfb28ae862230019dc1e" ]
+                },
+                {
                     "attributeCode": "attributes_itemsGeometry",
                     "value": {
                         "type": "Point",


### PR DESCRIPTION
If this goes live, we'll have to update the update cron to call the Alloy endpoints less often (assuming they'll now be taking longer than the update frequency).