### PR TITLE
Log different integrations to different files.

### DIFF
--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -1,6 +1,5 @@
 package Integrations::Bartec;
 
-use SOAP::Lite;
 use Exporter;
 use DateTime::Format::W3CDTF;
 use Carp ();
@@ -20,7 +19,7 @@ with 'Role::Memcached';
 # that I don't understand, so declare the attribute ourselves.
 has logger => (
     is => 'lazy',
-    default => sub { Open311::Endpoint::Logger->new },
+    default => sub { Open311::Endpoint::Logger->new(config_filename => $_[0]->config_filename) },
 );
 
 has ua => (

--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -35,7 +35,7 @@ sub credentials {
 # that I don't understand, so declare the attribute ourselves.
 has logger => (
     is => 'lazy',
-    default => sub { Open311::Endpoint::Logger->new },
+    default => sub { Open311::Endpoint::Logger->new(config_filename => $_[0]->config_filename) },
 );
 
 has ua => (

--- a/perllib/Open311/Endpoint/Integration/Bartec.pm
+++ b/perllib/Open311/Endpoint/Integration/Bartec.pm
@@ -69,6 +69,7 @@ has service_map => (
 );
 
 sub get_integration {
+    $_[0]->log_identifier($_[0]->jurisdiction_id);
     return $_[0]->bartec;
 }
 

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -428,6 +428,7 @@ sub get_integration {
     my $integ = $self->integration_class;
     $integ = $integ->on_fault(sub { my($soap, $res) = @_; die ref $res ? $res->faultstring : $soap->transport->status, "\n"; });
     $integ->config_filename($self->jurisdiction_id);
+    $self->log_identifier($self->jurisdiction_id);
     return $integ;
 }
 

--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -244,6 +244,7 @@ sub get_integration {
     my $integ = $self->integration_class->new(
         config_filename => $self->jurisdiction_id,
     );
+    $self->log_identifier($self->jurisdiction_id);
     return $integ;
 }
 

--- a/perllib/Open311/Endpoint/Integration/Ezytreev.pm
+++ b/perllib/Open311/Endpoint/Integration/Ezytreev.pm
@@ -24,6 +24,7 @@ has ezytreev => (
 );
 
 sub get_integration {
+    $_[0]->log_identifier($_[0]->jurisdiction_id);
     return $_[0]->ezytreev;
 }
 

--- a/perllib/Open311/Endpoint/Integration/SalesForce/EastSussex.pm
+++ b/perllib/Open311/Endpoint/Integration/SalesForce/EastSussex.pm
@@ -66,6 +66,7 @@ sub integration_class { 'Integrations::SalesForce::EastSussex' }
 
 sub get_integration {
     my $self = shift;
+    $self->log_identifier($self->jurisdiction_id);
     return $self->integration_class->new(config_filename => $self->jurisdiction_id);
 }
 

--- a/perllib/Open311/Endpoint/Integration/SalesForce/Rutland.pm
+++ b/perllib/Open311/Endpoint/Integration/SalesForce/Rutland.pm
@@ -48,6 +48,7 @@ sub integration_class { 'Integrations::SalesForce::Rutland' }
 
 sub get_integration {
     my $self = shift;
+    $self->log_identifier($self->jurisdiction_id);
     return $self->integration_class->new(config_filename => $self->jurisdiction_id);
 }
 

--- a/perllib/Open311/Endpoint/Integration/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/Symology.pm
@@ -206,6 +206,7 @@ sub get_integration {
     my $integ = $self->integration_class;
     $integ = $integ->on_fault(sub { my($soap, $res) = @_; die ref $res ? $res->faultstring : $soap->transport->status, "\n"; });
     $integ->config_filename($self->jurisdiction_id);
+    $self->log_identifier($self->jurisdiction_id);
     return $integ;
 }
 

--- a/perllib/Open311/Endpoint/Integration/Uniform.pm
+++ b/perllib/Open311/Endpoint/Integration/Uniform.pm
@@ -171,6 +171,7 @@ sub get_integration {
     my $integ = $self->integration_class;
     $integ = $integ->on_fault(sub { my($soap, $res) = @_; die ref $res ? $res->faultstring : $soap->transport->status, "\n"; })->want_som(1);
     $integ->config_filename($self->jurisdiction_id);
+    $self->log_identifier($self->jurisdiction_id);
     return $integ;
 }
 

--- a/perllib/Open311/Endpoint/Integration/WDM.pm
+++ b/perllib/Open311/Endpoint/Integration/WDM.pm
@@ -33,6 +33,7 @@ sub integration_class { 'Integrations::WDM' }
 
 sub get_integration {
     my $self = shift;
+    $self->log_identifier($self->jurisdiction_id);
     return $self->integration_class->new(config_filename => $self->jurisdiction_id);
 }
 

--- a/perllib/Open311/Endpoint/Role/ConfigFile.pm
+++ b/perllib/Open311/Endpoint/Role/ConfigFile.pm
@@ -21,7 +21,13 @@ around BUILDARGS => sub {
     my %args = @_;
 
     die unless $args{jurisdiction_id}; # Must have one by here
-    my $file = $args{config_filename} || "council-$args{jurisdiction_id}.yml";
+    my $file;
+    if ($args{config_filename}) {
+        $file = $args{config_filename};
+    } else {
+        $args{config_filename} = $args{jurisdiction_id};
+        $file = "council-$args{config_filename}.yml";
+    }
     $args{config_file} //= path(__FILE__)->parent(5)->realpath->child("conf/$file")->stringify;
 
     if (my $config_data = $args{config_data}) {

--- a/perllib/Open311/Endpoint/Role/mySociety.pm
+++ b/perllib/Open311/Endpoint/Role/mySociety.pm
@@ -78,12 +78,18 @@ around dispatch_request => sub {
     );
 };
 
+my $log_identifier;
+sub log_identifier {
+    my $self = shift;
+    $log_identifier = shift;
+}
+
 sub log_soap_message {
     # uncoverable subroutine
     # uncoverable statement
     my ($msg) = @_;
 
-    my $l = Open311::Endpoint::Logger->new;
+    my $l = Open311::Endpoint::Logger->new( config_filename => $log_identifier );
     if ( ref($msg) eq 'HTTP::Request' || ref($msg) eq 'HTTP::Response' ) {
         $l->debug($msg->content);
     }

--- a/perllib/Role/EndpointConfig.pm
+++ b/perllib/Role/EndpointConfig.pm
@@ -8,6 +8,11 @@ use Path::Tiny;
 use YAML::XS qw(LoadFile);
 use Moo::Role;
 
+has config_filename => (
+    is => 'lazy',
+    default => sub { $_[0]->jurisdiction_id },
+);
+
 has config_file => (
     is => 'lazy',
     coerce => sub { path($_[0]) },
@@ -16,7 +21,7 @@ has config_file => (
 sub _build_config_file {
     my $self = shift;
     my $path = path(__FILE__)->parent(3)->realpath->child('conf');
-    $path->child('council-' . $self->jurisdiction_id . '.yml');
+    $path->child('council-' . $self->config_filename . '.yml');
 }
 
 has endpoint_config => (

--- a/perllib/Role/Logger.pm
+++ b/perllib/Role/Logger.pm
@@ -5,7 +5,13 @@ use Open311::Endpoint::Logger;
 
 has logger => (
     is => 'lazy',
-    default => sub { Open311::Endpoint::Logger->new },
+    default => sub {
+        # Not all things using this logger have config_filename set up
+        my $config = $_[0]->can('config_filename') ? $_[0]->config_filename : '';
+        Open311::Endpoint::Logger->new(
+            config_filename => $config,
+        );
+    },
 );
 
 1;


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3658. This should cover anything using Role::Logger and SOAP::Lite.

Role::Logger now passes in its config filename (if present) to the Open311::Endpoint::Logger to be used to look up the log file location (rather than always falling back to general.yml). The changes to O::E::Role::ConfigFile and Role::EndpointConfig are only so that config_filename is set for more things (that otherwise skipped straight to setting `config_file`).

SOAP::Lite only has the one hook for debug logging, so I set a log identifier in the Endpoint package before each call to the SOAP API, to log to the appropriate place. Bit ugly, but seems to work in staging.