### PR TITLE
Abavus update read fields and add photos field

### DIFF
--- a/perllib/Integrations/Abavus.pm
+++ b/perllib/Integrations/Abavus.pm
@@ -49,10 +49,9 @@ sub api_call {
         $self->logger->error($response->content);
         try {
             my $json_response = decode_json($response->content);
-            my $code = $json_response->{errorCode} || "";
-            my $codeString = $json_response->{errorCodeString} || "";
-            my $msg = $json_response->{debugErrorMessage} || "";
-            die "Abavus API call failed: [$code $codeString] $msg";
+            my $code = $json_response->{code} || "";
+            my $msg = $json_response->{message} || "";
+            die "Abavus API call failed: [$code] $msg";
         } catch {
             die $response->content;
         };

--- a/perllib/Open311/Endpoint/Integration/Abavus.pm
+++ b/perllib/Open311/Endpoint/Integration/Abavus.pm
@@ -193,6 +193,7 @@ sub post_service_request {
         $args->{full_name} = $args->{first_name} . ' ' . $args->{last_name};
         $args->{fixmystreet_id} = $args->{attributes}{fixmystreet_id};
         $args->{title} = $args->{attributes}{title};
+        $args->{photos} = scalar $args->{media_url} ? join( ",", @{ $args->{media_url} } ) : '';
         $self->add_question_responses($response->{id}, $args);
     }
 

--- a/perllib/Open311/Endpoint/Integration/Abavus.pm
+++ b/perllib/Open311/Endpoint/Integration/Abavus.pm
@@ -189,7 +189,7 @@ sub post_service_request {
         body => $serviceRequest
     );
 
-    if ($response->{id} != '-1') {
+    if ($response->{result}) {
         $args->{full_name} = $args->{first_name} . ' ' . $args->{last_name};
         $args->{fixmystreet_id} = $args->{attributes}{fixmystreet_id};
         $args->{title} = $args->{attributes}{title};
@@ -197,7 +197,7 @@ sub post_service_request {
         $self->add_question_responses($response->{id}, $args);
     }
 
-    if ($response->{id} != '-1') {
+    if ($response->{result}) {
         return $self->new_request(
         service_request_id => $response->{id}
     )};

--- a/t/open311/endpoint/abavus.t
+++ b/t/open311/endpoint/abavus.t
@@ -11,6 +11,8 @@ use URI;
 extends 'Integrations::Abavus';
 
 my $lwp = Test::MockModule->new('LWP::UserAgent');
+my $lwp_counter = 0;
+
 $lwp->mock(request => sub {
     my ($ua, $req) = @_;
 
@@ -21,6 +23,7 @@ $lwp->mock(request => sub {
         'http://localhost/api/serviceRequest/questions/1?questionCode=ABANDONED_SITE_SUMMERISE_646538_I&answer=Abandoned%20Cortina' => 1,
         'http://localhost/api/serviceRequest/questions/1?questionCode=ABANDONED_SITE_EMAIL_646943_I&answer=test@example.com' => 1,
         'http://localhost/api/serviceRequest/questions/1?questionCode=ABANDONED_ISSUE_TYPE_646538_I&answer=ABANDONED_916276_A' => 1,
+        'http://localhost/api/serviceRequest/questions/1?questionCode=ABANDONED_SITE_PHOTOS_646943_I&answer=one.jpg,two.jpg' => 1,
     );
 
     if ($req->uri =~ /serviceRequest$/) {
@@ -35,6 +38,7 @@ $lwp->mock(request => sub {
     } else {
         is $req->method, 'POST', "Correct method used";
         is $put_requests{$req->uri}, 1, "Call formed correctly";
+        ++$lwp_counter;
         return HTTP::Response->new(200, 'OK', [], encode_json({"id" => 1}));
     }
 });
@@ -127,6 +131,7 @@ subtest "POST report" => sub {
         last_name => 'Mould',
         email => 'test@example.com',
         description => 'Car abandoned for a week',
+        media_url => ['one.jpg','two.jpg'],
         lat => '50',
         long => '0.1',
         'attribute[description]' => 'description',
@@ -139,6 +144,7 @@ subtest "POST report" => sub {
         'attribute[fixmystreet_id]' => 1,
         'attribute[ABANDONED_ISSUE_TYPE_646538_I]' => 'ABANDONED_916276_A',
         );
+    is $lwp_counter, 7, "Seven fields added";
     is $res->code, 200;
 };
 

--- a/t/open311/endpoint/abavus.t
+++ b/t/open311/endpoint/abavus.t
@@ -34,12 +34,12 @@ $lwp->mock(request => sub {
         is $content->{serviceRequest}->{form}->{code}, 'ABANDONED_17821_C';
         is $content->{serviceRequest}->{location}->{latitude}, '50';
         is $content->{serviceRequest}->{location}->{longitude}, '0.1';
-        return HTTP::Response->new(200, 'OK', [], encode_json({"id" => 1}));
+        return HTTP::Response->new(200, 'OK', [], encode_json({"result" => 1, "id" => 1}));
     } else {
         is $req->method, 'POST', "Correct method used";
         is $put_requests{$req->uri}, 1, "Call formed correctly";
         ++$lwp_counter;
-        return HTTP::Response->new(200, 'OK', [], encode_json({"id" => 1}));
+        return HTTP::Response->new(200, 'OK', [], encode_json({"result" => 1, "id" => 1}));
     }
 });
 

--- a/t/open311/endpoint/abavus.yml
+++ b/t/open311/endpoint/abavus.yml
@@ -44,3 +44,4 @@ service_code_fields:
     description: EXPLAIN_ABANDONED_SITE_646941_I
     full_name: ABANDONED_SITE_FULL_NAME_646942_I
     email: ABANDONED_SITE_EMAIL_646943_I
+    photos: ABANDONED_SITE_PHOTOS_646943_I


### PR DESCRIPTION
Checks against the 'result' rather than the 'id' - there should be one result for creating a serviceRequest and 0 for failure. Seems more solid than the 'id' returning -1 which I couldn't see documented.

Also changes fields read to correct Abavus return field names.

Adds in a photo field to send the urls of photos on the report.

Also adds a test for the photo field and a check that all fields are being tested as currently there could be a silent failure if checking fields breaks down.