### PR TITLE
[Bucks][Abavus] Add adding of reference and systemCode

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Abavus.pm
+++ b/perllib/Open311/Endpoint/Integration/Abavus.pm
@@ -190,6 +190,12 @@ sub post_service_request {
     );
 
     if ($response->{result}) {
+        $self->abavus->api_call(
+            call => 'serviceRequest/integrationReference/' . $response->{id}
+            . '?reference=' . $args->{attributes}{fixmystreet_id}
+            . '&systemCode=FMS',
+            method => 'PUT'
+        );
         $args->{full_name} = $args->{first_name} . ' ' . $args->{last_name};
         $args->{fixmystreet_id} = $args->{attributes}{fixmystreet_id};
         $args->{title} = $args->{attributes}{title};

--- a/t/open311/endpoint/abavus.t
+++ b/t/open311/endpoint/abavus.t
@@ -35,6 +35,10 @@ $lwp->mock(request => sub {
         is $content->{serviceRequest}->{location}->{latitude}, '50';
         is $content->{serviceRequest}->{location}->{longitude}, '0.1';
         return HTTP::Response->new(200, 'OK', [], encode_json({"result" => 1, "id" => 1}));
+    } elsif ($req->uri =~ /serviceRequest\/integrationReference/) {
+        is $req->method, 'PUT', "Correct method used";
+        is $req->uri, 'http://localhost/api/serviceRequest/integrationReference/1?reference=1&systemCode=FMS';
+        return HTTP::Response->new(200, 'OK', [], encode_json({"result" => 1, "id" => 1}));
     } else {
         is $req->method, 'POST', "Correct method used";
         is $put_requests{$req->uri}, 1, "Call formed correctly";


### PR DESCRIPTION
When creating a report it needs to have a systemCode and a reference added - systemCode is hardcoded to 'FMS' to match the Bucks profile.

reference is the FMS id as the external id.

This is for the forthcoming 'event' call that will allow fetching updated reports and will need these present to work at the Abavus end.

https://3.basecamp.com/4020879/buckets/32325686/todos/6191167800#__recording_6245727608