### PR TITLE
[Shropshire] Allow different staff contact code.

### DIFF
--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -418,7 +418,7 @@ sub NewEnquiry {
     if (my $enquiry_method = $self->enquiry_method_code) {
         push @customer, SOAP::Data->name('EnquiryMethodCode' => SOAP::Utils::encode_data($enquiry_method))->type("");
     }
-    if (my $point_of_contact = $self->point_of_contact_code) {
+    if (my $point_of_contact = ($args->{point_of_contact_code} || $self->point_of_contact_code)) {
         push @customer, SOAP::Data->name('PointOfContactCode' => SOAP::Utils::encode_data($point_of_contact))->type("");
     }
     if (my $customer_type = $self->customer_type_code) {

--- a/perllib/Open311/Endpoint/Integration/UK/Shropshire.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Shropshire.pm
@@ -9,4 +9,16 @@ around BUILDARGS => sub {
     return $class->$orig(%args);
 };
 
+around process_service_request_args => sub {
+    my ($orig, $self, $args) = (@_);
+
+    my $ret = $self->$orig($args);
+
+    if (my $poc = delete $args->{attributes}{contributed_by}) {
+        $ret->{point_of_contact_code} = 'CSC';
+    }
+
+    return $ret;
+};
+
 1;

--- a/t/open311/endpoint/shropshire.t
+++ b/t/open311/endpoint/shropshire.t
@@ -1,0 +1,78 @@
+package Integrations::Confirm::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Integrations::Confirm';
+sub _build_config_file { path(__FILE__)->sibling("confirm.yml")->stringify }
+
+package Open311::Endpoint::Integration::UK::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Open311::Endpoint::Integration::UK::Shropshire';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'confirm_dummy';
+    $args{config_file} = path(__FILE__)->sibling("confirm.yml")->stringify;
+    return $class->$orig(%args);
+};
+has integration_class => (is => 'ro', default => 'Integrations::Confirm::Dummy');
+
+package main;
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use JSON::MaybeXS;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+my $open311 = Test::MockModule->new('Integrations::Confirm');
+$open311->mock(perform_request => sub {
+    my ($self, $op) = @_; # Don't care about subsequent ops
+    $op = $$op;
+    if ($op->name && $op->name eq 'GetEnquiryLookups') {
+        return {
+            OperationResponse => { GetEnquiryLookupsResponse => { TypeOfService => [
+                { ServiceCode => 'ABC', ServiceName => 'Graffiti', EnquirySubject => [ { SubjectCode => "DEF" } ] },
+            ] } }
+        };
+    }
+    $op = $op->value;
+    if ($op->name eq 'NewEnquiry') {
+        my %req = map { $_->name => $_->value } ${$op->value}->value;
+        my %customer = map { $_->name =>$_->value } ${$req{EnquiryCustomer}}->value;
+        is $customer{PointOfContactCode}, 'CSC';
+        return { OperationResponse => { NewEnquiryResponse => { Enquiry => { EnquiryNumber => 2001 } } } };
+    }
+    return {};
+});
+
+my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
+
+subtest "POST OK" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        api_key => 'test',
+        service_code => 'ABC_DEF',
+        address_string => '22 Acacia Avenue',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the details",
+        'attribute[easting]' => 100,
+        'attribute[northing]' => 100,
+        'attribute[fixmystreet_id]' => 1001,
+        'attribute[title]' => 'Title',
+        'attribute[description]' => 'This is the details',
+        'attribute[report_url]' => 'http://example.com/report/1001',
+        'attribute[contributed_by]' => 1,
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => 2001
+        } ], 'correct json returned';
+};
+
+done_testing;


### PR DESCRIPTION
This allows for, if FMS sends through a contributed_by attribute, flagging the PointOfContactCode as something different.
For FD-2689
FMS change at https://github.com/mysociety/fixmystreet/pull/4499