### PR TITLE
[Multi] Error if any failure in a services call.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Multi.pm
+++ b/perllib/Open311/Endpoint/Integration/Multi.pm
@@ -36,14 +36,16 @@ sub _call {
 }
 
 sub _all {
-    my ($self, $fn, $args) = @_;
+    my ($self, $fn, $args, %opts) = @_;
     my @all;
     foreach (@{$self->integrations}) {
         my $name = $_->{name};
         my @results = try {
             $_->{class}->$fn($args);
         } catch {
-            warn "The call to $fn in $name failed with error: $_\n";
+            my $err = "The call to $fn in $name failed with error: $_\n";
+            die $err if $opts{die};
+            warn $err;
             ();
         };
         @results = map { [ $name, $_ ] } @results;
@@ -100,7 +102,7 @@ to include which child the service has come from (in case any codes overlap).
 
 sub services {
     my ($self, $args) = @_;
-    my @services = $self->_all(services => $args);
+    my @services = $self->_all(services => $args, die => 1);
     @services = $self->_map_with_new_id(service_code => @services);
     return @services;
 }

--- a/t/open311/endpoint/multi.t
+++ b/t/open311/endpoint/multi.t
@@ -1,0 +1,40 @@
+package Open311::Endpoint::Integration::UK::Dummy;
+use Moo;
+extends 'Open311::Endpoint::Integration::Multi';
+use Module::Pluggable
+    search_path => ['Open311::Endpoint::Integration::UK::Dummy'],
+    instantiate => 'new';
+
+package Open311::Endpoint::Integration::UK::Dummy::SubA;
+use Moo;
+extends 'Open311::Endpoint';
+sub services {
+    die "Fail!";
+}
+
+package Open311::Endpoint::Integration::UK::Dummy::SubB;
+use Moo;
+extends 'Open311::Endpoint';
+sub services {
+    my $service = Open311::Endpoint::Service->new(
+        service_name => 'test',
+        service_code => 'test',
+        description => 'test',
+    );
+    return ($service);
+}
+
+package main;
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+use_ok('Open311::Endpoint::Integration::UK::Dummy');
+
+my $e = Open311::Endpoint::Integration::UK::Dummy->new;
+
+dies_ok { $e->services } 'Calling multi services when one fails, dies';
+
+done_testing;


### PR DESCRIPTION
If one backend of a Multi endpoint fails, and we skip it, only the non-erroring results will be returned, leading to the erroring services being removed from the front end.
Fixes https://github.com/mysociety/open311-adapter/issues/275