### PR TITLE
[open311-adapter] [Central Beds] Allow zero lookback-days when initialising Jadu state gathering files.

### DIFF
--- a/bin/centralbedfordshire/jadu/init_update_gathering_files
+++ b/bin/centralbedfordshire/jadu/init_update_gathering_files
@@ -18,7 +18,7 @@ use Open311::Endpoint::Integration::UK::CentralBedfordshire::Jadu;
 
 my $lookback_days;
 GetOptions("lookback-days=i" => \$lookback_days);
-if (!$lookback_days) {
+if (!defined($lookback_days)) {
     print "Please specify a number of days to look back for updates via --lookback-days";
     exit 1;
 }


### PR DESCRIPTION
Small thing I bumped in to when go-living.