### PR TITLE
[Echo] Allow PostEvent GUID to be set by Open311

### DIFF
--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -169,6 +169,7 @@ sub PostEvent {
         );
     }
     my $data = ixhash(
+        $args->{guid} ? (Guid => $args->{guid}) : (),
         $args->{data} ? (Data => extensible_data($args->{data})) : (),
         ClientReference => $args->{client_reference},
         EventObjects => { EventObject => $source },

--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -426,6 +426,12 @@ sub process_service_request_args {
         data => [],
     };
 
+    # We may want to raise the event with a specific GUID which has been
+    # passed in as an extended attribute.
+    if (my $guid = $args->{attributes}{GUID}) {
+       $request->{guid} = $guid;
+    }
+
     return $request;
 }
 


### PR DESCRIPTION
For e.g. bulky collections the same GUID used by FMS in the `ReserveAvailableSlotsForEvent` call must be used for subsequent `PostEvent` call.

For https://github.com/mysociety/societyworks/issues/3758