### PR TITLE
[ATAK] Enforce character limit on issue text.

### DIFF
--- a/conf/council-brent_atak.yml-example
+++ b/conf/council-brent_atak.yml-example
@@ -4,6 +4,7 @@ api_url: https://testatak.krinkels.com/ords/hws/atak/v1
 # api_url: https://atak.krinkels.com/ords/hws/atak/v1
 project_code: C23005
 project_name: LB BRENT GM SERVICES
+max_issue_text_characters: 900
 
 services:
   LITTER_BIN_NEEDS_EMPTYING:

--- a/perllib/Open311/Endpoint/Service/UKCouncil/ATAK.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/ATAK.pm
@@ -18,6 +18,30 @@ sub _build_attributes {
             automated => 'hidden_field',
             allow_any_attributes => 1,
         ),
+
+        Open311::Endpoint::Service::Attribute->new(
+            code => "report_url",
+            description => "Report URL",
+            datatype => "string",
+            required => 1,
+            automated => 'server_set',
+        ),
+
+        Open311::Endpoint::Service::Attribute->new(
+            code => "title",
+            description => "Title",
+            datatype => "string",
+            required => 1,
+            automated => 'server_set',
+        ),
+
+        Open311::Endpoint::Service::Attribute->new(
+            code => "detail",
+            description => "Detail",
+            datatype => "text",
+            required => 1,
+            automated => 'server_set',
+        ),
     );
 
     return \@attributes;


### PR DESCRIPTION
https://github.com/mysociety/societyworks/issues/3898

Construct the description open311-adapter side using title, URL and detail values from FMS. Truncate the detail to ensure the whole issue text is less than some config defined character limit.