### PR TITLE
[ATAK] Add group to issue text

### DIFF
--- a/perllib/Open311/Endpoint/Integration/ATAK.pm
+++ b/perllib/Open311/Endpoint/Integration/ATAK.pm
@@ -70,6 +70,7 @@ sub post_service_request {
     my $issue_text = $self->_format_issue_text(
         $self->endpoint_config->{max_issue_text_characters},
         $service->service_name,
+        $args->{attributes}->{group},
         $args->{attributes}->{location_name} || '',
         $args->{attributes}->{report_url},
         $args->{attributes}->{title},
@@ -109,12 +110,12 @@ sub post_service_request {
 }
 
 sub _format_issue_text {
-    my ($self, $char_limit, $category, $location_name, $url, $title, $detail) = @_;
+    my ($self, $char_limit, $category, $group, $location_name, $url, $title, $detail) = @_;
 
     # Populate everything except the detail field which we may need to truncate.
     my $issue_text = sprintf(
-        "Category: %s\nLocation: %s\n\nlocation of problem: %s\n\ndetail: %%s\n\nurl: %s\n\nSubmitted via FixMyStreet\n",
-        $category, $location_name, $title, $url
+        "Category: %s\nGroup: %s\nLocation: %s\n\nlocation of problem: %s\n\ndetail: %%s\n\nurl: %s\n\nSubmitted via FixMyStreet\n",
+        $category, $group, $location_name, $title, $url
     );
 
     # +2 for the not yet used format directive for detail (%s).

--- a/perllib/Open311/Endpoint/Service/UKCouncil/ATAK.pm
+++ b/perllib/Open311/Endpoint/Service/UKCouncil/ATAK.pm
@@ -42,6 +42,13 @@ sub _build_attributes {
             required => 1,
             automated => 'server_set',
         ),
+        Open311::Endpoint::Service::Attribute->new(
+            code => "group",
+            description => "Group",
+            datatype => "string",
+            required => 1,
+            automated => 'server_set',
+        ),
     );
 
     return \@attributes;

--- a/t/open311/endpoint/brent.t
+++ b/t/open311/endpoint/brent.t
@@ -592,7 +592,7 @@ subtest "POST Parks littering ATAK service request OK" => sub {
             is $headers{Authorization}, 'AUTH-123';
 
             my $data = decode_json($headers{Content})->{tasks}->[0];
-            is $data->{issue}, "Category: Parks littering\nLocation: Location name\n\n" .
+            is $data->{issue}, "Category: Parks littering\nGroup: Parks and open spaces\nLocation: Location name\n\n" .
                 "location of problem: title\n\ndetail: detail\n\nurl: url\n\n" .
                 "Submitted via FixMyStreet\n";
             is $data->{client_ref}, '42';
@@ -634,6 +634,7 @@ subtest "POST Parks littering ATAK service request OK" => sub {
         'attribute[report_url]' => 'url',
         'attribute[detail]' => 'detail',
         'attribute[title]' => 'title',
+        'attribute[group]' => 'Parks and open spaces',
     );
     ok $res->is_success, 'valid request';
 
@@ -947,25 +948,25 @@ subtest "GET ATAK service request updates OK" => sub {
 subtest "ATAK issue text formatting" => sub {
 
     dies_ok { $atak_endpoint->_format_issue_text(
-        120, 'category', 'location name', 'url', 'title', 'detail'
-    ) }, "formatting issue text fails when inputs are too big";
+        133, 'category', 'group', 'location name', 'url', 'title', 'detail'
+    ) } "formatting issue text fails when inputs are too big";
 
     my $issue_text =  $atak_endpoint->_format_issue_text(
-        121, 'category', 'location name', 'url', 'title', 'detail'
+        134, 'category', 'group', 'location name', 'url', 'title', 'detail'
     );
-    is $issue_text, "Category: category\nLocation: location name\n\nlocation of problem: title\n\n" .
+    is $issue_text, "Category: category\nGroup: group\nLocation: location name\n\nlocation of problem: title\n\n" .
         "detail: ...\n\nurl: url\n\nSubmitted via FixMyStreet\n";
 
     $issue_text =  $atak_endpoint->_format_issue_text(
-        122, 'category', 'location name', 'url', 'title', 'detail'
+        135, 'category', 'group', 'location name', 'url', 'title', 'detail'
     );
-    is $issue_text, "Category: category\nLocation: location name\n\nlocation of problem: title\n\n" .
+    is $issue_text, "Category: category\nGroup: group\nLocation: location name\n\nlocation of problem: title\n\n" .
         "detail: d...\n\nurl: url\n\nSubmitted via FixMyStreet\n";
 
     $issue_text =  $atak_endpoint->_format_issue_text(
-        126, 'category', 'location name', 'url', 'title', 'detail'
+        139, 'category', 'group', 'location name', 'url', 'title', 'detail'
     );
-    is $issue_text, "Category: category\nLocation: location name\n\nlocation of problem: title\n\n" .
+    is $issue_text, "Category: category\nGroup: group\nLocation: location name\n\nlocation of problem: title\n\n" .
         "detail: detail\n\nurl: url\n\nSubmitted via FixMyStreet\n";
 };
 


### PR DESCRIPTION
Add group to the issue text when creating an issue in ATAK.

See also https://github.com/mysociety/fixmystreet/pull/4600, which populates the group attribute on the FMS side.

Fixes https://github.com/mysociety/societyworks/issues/3836