### PR TITLE
[Bartec] Encode email in case of special characters

### DIFF
--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -433,7 +433,7 @@ sub ServiceRequest_Create {
         reporterContact => {
             Forename => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd' }, value => SOAP::Utils::encode_data($values->{first_name}) },
             Surname => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd' }, value => SOAP::Utils::encode_data($values->{last_name}) },
-            Email => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd'} , value => $values->{email} },
+            Email => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd'} , value => SOAP::Utils::encode_data($values->{email}) },
             $values->{phone} ? ( Telephone => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd'} , value => $values->{phone} } ) : (),
             ReporterType => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd'}, value => $values->{ReporterType} },
         },

--- a/t/open311/endpoint/bartec.t
+++ b/t/open311/endpoint/bartec.t
@@ -569,7 +569,7 @@ subtest "check send report with extended info & ampersands " => sub {
         service_code => '4',
         first_name => 'Bob',
         last_name => 'Mould & Test',
-        email => 'test@example.com',
+        email => 'te&st@example.com',
         description => 'description',
         lat => '52.540930',
         long => '-0.289832',
@@ -643,7 +643,7 @@ subtest "check send report with extended info & ampersands " => sub {
         reporterContact => {
             Forename => 'Bob',
             Surname => 'Mould & Test',
-            Email => 'test@example.com',
+            Email => 'te&st@example.com',
             ReporterType => 'Public',
         }
     }, 'correct request sent';


### PR DESCRIPTION
Add encoding to email addresses in case of special characters in email addresses prompted by an email with an ampersand in it