### PR TITLE
[Brent][ATAK] Set external status code for closed reports

### DIFF
--- a/conf/council-brent_atak.yml-example
+++ b/conf/council-brent_atak.yml-example
@@ -27,3 +27,4 @@ atak_status_to_fms_status:
     "Closed - Not found": "closed"
     "Closed - Passed to Brent": "internal_referral"
 fixed_status: "Closed - Completed"
+closed_status: "Closed - Not found"

--- a/perllib/Open311/Endpoint/Integration/ATAK.pm
+++ b/perllib/Open311/Endpoint/Integration/ATAK.pm
@@ -371,11 +371,12 @@ sub _fetch_and_apply_updated_issues_info {
         # Task comments field is present, not blank, but doesn't start with a known ATAK status.
         if (!$mapped_fms_status) {
             $self->logger->debug(sprintf(
-                    "[ATAK] Updated issue %s has unmapped ATAK status '%s'. Skipping.",
+                    "[ATAK] Updated issue %s has unmapped ATAK status '%s'. Defaulting to closed status.",
                     $issue_reference,
                     $task_comments
                 ));
             $mapped_fms_status = 'closed';
+            $atak_status = $self->endpoint_config->{closed_status};
         }
 
         my $existing_tracking = $tracked_statuses->{issues}->{$issue_reference};

--- a/t/open311/endpoint/brent.t
+++ b/t/open311/endpoint/brent.t
@@ -88,6 +88,7 @@ sub atak_config {
             "Closed - Passed to Brent" => "internal_referral",
         },
         fixed_status => "Closed - Completed",
+        closed_status => "Closed - Not found",
     }
 }
 
@@ -916,6 +917,7 @@ subtest "GET ATAK service request updates OK" => sub {
                 status => 'closed',
                 update_id => 'ATAK-unknown_state_1690848000',
                 updated_datetime => '2023-08-01T00:00:00Z',
+                external_status_code => 'Closed - Not found',
             }
         ]
     );
@@ -932,6 +934,16 @@ subtest "GET ATAK service request updates OK" => sub {
         return HTTP::Response->new(200, 'OK', [], '{
             "tasks": [
                 {
+                    "testing_comment": "same ATAK status - should ignore",
+                    "client_ref": "unknown_state",
+                    "task_comments": "Closed - Unknown",
+                    "task_d_created": "2023-08-01T00:00:00Z",
+                    "task_d_planned": "2023-08-01T00:00:00Z",
+                    "task_d_completed": "2023-08-01T00:00:00Z",
+                    "task_d_approved": "2023-08-01T00:00:00Z",
+                    "task_p_id": "125"
+                },
+                {
                     "testing_comment": "new update but same ATAK status - should ignore",
                     "client_ref": "test",
                     "task_comments": "Closed - Passed to Brent",
@@ -939,7 +951,7 @@ subtest "GET ATAK service request updates OK" => sub {
                     "task_d_planned": "2023-08-02T01:00:00Z",
                     "task_d_completed": "2023-08-02T02:00:00Z",
                     "task_d_approved": "2023-08-04T03:00:00Z",
-                    "task_p_id": "128"
+                    "task_p_id": "127"
                 }
             ]
         }');
@@ -977,6 +989,7 @@ subtest "GET ATAK service request updates OK" => sub {
                 status => 'closed',
                 update_id => 'ATAK-unknown_state_1690848000',
                 updated_datetime => '2023-08-01T00:00:00Z',
+                external_status_code => 'Closed - Not found',
             }
         ]
     );


### PR DESCRIPTION
We were already setting the FMS status code correctly, but were missing the external status code for reports that were automatically marked as closed, which was causing some warnings.