### PR TITLE
[Symology] Update when only default ServiceCode.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Symology.pm
+++ b/perllib/Open311/Endpoint/Integration/Symology.pm
@@ -231,9 +231,15 @@ sub post_service_request {
 sub process_service_request_update_args {
     my ($self, $args) = @_;
 
+    my $services = $self->category_mapping;
+    my $any_request_service_code;
+    foreach (keys %$services) {
+        $any_request_service_code ||= $services->{$_}{parameters}{ServiceCode};
+    }
+
     my $service_code = $args->{service_code};
     my $codes = $self->category_mapping->{$service_code};
-    die "Could not find category mapping for $service_code\n" unless $codes;
+    die "Could not find category mapping for $service_code\n" if !$codes && $any_request_service_code;
 
     my $closed = $args->{status} =~ /FIXED|DUPLICATE|NOT_COUNCILS_RESPONSIBILITY|NO_FURTHER_ACTION|INTERNAL_REFERRAL|CLOSED/;
 

--- a/t/open311/endpoint/bexley_symology.t
+++ b/t/open311/endpoint/bexley_symology.t
@@ -432,6 +432,26 @@ subtest "POST with bad rules fails" => sub {
         or diag $res->content;
 };
 
+subtest "POST update on gone category" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/servicerequestupdates.json',
+        jurisdiction_id => 'bexley',
+        api_key => 'test',
+        updated_datetime => '2019-03-01T12:00:00Z',
+        service_code => 'GONE',
+        service_request_id => 1001,
+        status => 'OPEN',
+        description => "This is the update",
+        update_id => 456,
+    );
+    ok !$res->is_success, 'invalid request'
+        or diag $res->content;
+    is_deeply decode_json($res->content), [ {
+        "description" => "Could not find category mapping for GONE\n",
+        "code" => 500,
+    } ], 'correct json returned';
+};
+
 subtest "POST update OK" => sub {
     my $res = $endpoint->run_test_request(
         POST => '/servicerequestupdates.json',

--- a/t/open311/endpoint/brent.t
+++ b/t/open311/endpoint/brent.t
@@ -740,6 +740,29 @@ subtest "POST Echo update on closed report OK" => sub {
         } ], 'correct json returned';
 };
 
+subtest "POST update on gone category OK, as only default ServiceCode" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/servicerequestupdates.json',
+        jurisdiction_id => 'brent',
+        api_key => 'test',
+        updated_datetime => '2019-03-01T12:00:00Z',
+        service_code => 'Symology-GONE',
+        service_request_id => "Symology-1001",
+        status => 'OPEN',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the update",
+        service_request_id_ext => 5678,
+        update_id => 456,
+        media_url => 'http://example.org/photo/1.jpeg',
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+    is_deeply decode_json($res->content), [ {
+        'update_id' => 'Symology-456',
+    } ], 'correct json returned';
+};
+
 subtest "POST update OK" => sub {
     my $res = $endpoint->run_test_request(
         POST => '/servicerequestupdates.json',


### PR DESCRIPTION
The category configuration is only needed if the category has a specific ServiceCode. So if no category has a specific ServiceCode, we can assume we can pass through updates regardless of if the category matches one or not. This lets us send through updates on now-deleted category reports.