### PR TITLE
[Alloy] Strip multiple extensions from the service code.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/AlloyV2.pm
+++ b/perllib/Open311/Endpoint/Integration/AlloyV2.pm
@@ -205,7 +205,7 @@ sub post_service_request {
     my $resource_id = $args->{attributes}->{asset_resource_id} || '';
 
     my $category = $args->{service_code};
-    $category =~ s/_\d+$//;
+    $category =~ s/(_\d+)+$//;
     $category =~ s/_/ /g;
     $args->{service_code_alloy} = $category;
 

--- a/t/open311/endpoint/json/alloyv2/northumberland_categories_query_response.json
+++ b/t/open311/endpoint/json/alloyv2/northumberland_categories_query_response.json
@@ -29,6 +29,34 @@
                 }
             ],
             "signature": "61fb0065908ed5015b93083c"
+        },
+        {
+            "itemId": "61fb016c4c5c56015448093e",
+            "designCode": "designs_cRMRequests_5d89e289ca31500a94693c9c",
+            "collection": "Live",
+            "icon": "icon-display-list",
+            "colour": "#8b8b8b",
+            "locked": false,
+            "context": "Customer",
+            "attributes": [
+                {
+                    "attributeCode": "attributes_cRMRequestsCode_5d89e2e9ca31500a94693ca4",
+                    "value": "Loose / Raised / Sunken"
+                },
+                {
+                    "attributeCode": "attributes_cRMRequestsDescription_5d89e30aca31500a94693cab",
+                    "value": "Loose / Raised / Sunken"
+                },
+                {
+                    "attributeCode": "attributes_itemsTitle",
+                    "value": "Loose / Raised / Sunken"
+                },
+                {
+                    "attributeCode": "attributes_itemsSubtitle",
+                    "value": "CRM Requests Category"
+                }
+            ],
+            "signature": "61fb0065908ed5015b93083b"
         }
     ]
 }

--- a/t/open311/endpoint/northumberland_alloy.t
+++ b/t/open311/endpoint/northumberland_alloy.t
@@ -285,6 +285,12 @@ subtest "check service group and category aliases" => sub {
         } elsif ($_->{service_code} eq 'Loose_/_Raised_/_Sunken_1') {
             is_deeply $_->{groups}, ["Roads"];
             is $_->{service_name}, "Sunken drain";
+        } elsif ($_->{service_code} eq 'Loose_/_Raised_/_Sunken_1_1') {
+            is_deeply $_->{groups}, ["Roads"];
+            is $_->{service_name}, "Raised drain";
+        } elsif ($_->{service_code} eq 'Loose_/_Raised_/_Sunken_2_1') {
+            is_deeply $_->{groups}, ["Roads"];
+            is $_->{service_name}, "Loose drain";
         }
     }
 
@@ -320,6 +326,24 @@ subtest "create problem on aliased group" => sub {
     # order these so comparison works
     $sent->{attributes} = [ sort { $a->{attributeCode} cmp $b->{attributeCode} } @{ $sent->{attributes} } ];
     is $sent->{attributes}[6]{value}[0], '61fafee3e3b879015205f7cc', 'correct group found';
+};
+
+subtest "create problem on double-extension category" => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        %shared_params,
+        service_code => 'Loose_/_Raised_/_Sunken_1_1',
+        'attribute[category]' => 'Loose_/_Raised_/_Sunken_1_1',
+        'attribute[group]' => 'Roads',
+    );
+
+    my $sent = pop @sent;
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    # order these so comparison works
+    $sent->{attributes} = [ sort { $a->{attributeCode} cmp $b->{attributeCode} } @{ $sent->{attributes} } ];
+    is $sent->{attributes}[5]{value}[0], '61fb016c4c5c56015448093e', 'correct group found';
 };
 
 subtest "create problem on groupless category" => sub {

--- a/t/open311/endpoint/northumberland_alloy.yml
+++ b/t/open311/endpoint/northumberland_alloy.yml
@@ -107,6 +107,8 @@
         "Flooding": 1,
         "Highway Condition": 1,
         "Loose / Raised / Sunken": { "alias": "Sunken drain" },
+        "Loose / Raised / Sunken_1": { "alias": "Raised drain" },
+        "Loose / Raised / Sunken_2": { "alias": "Loose drain" },
         "Mud on Road": 1,
         "Potholes": 1,
         "Spill - Oil/Diesel": 1,


### PR DESCRIPTION
This is to allow two subcategories in the same category to go to the same destination category in Alloy, e.g.

Road and street signs:
  Sign light not working: { "alias": "Sign with a light (blue)" },
  Sign light not working_1: { "alias": "Sign with a light (other)" },

It was fine if they were in different top-level categories, but impossible if they were in the same. This is a bit of a workaround, but seemed to be okay. For FD-3900.