### PR TITLE
[Bexley][Whitespace] Use custom message for worksheet

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/Bexley/Whitespace.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Bexley/Whitespace.pm
@@ -9,4 +9,11 @@ around BUILDARGS => sub {
     return $class->$orig(%args);
 };
 
+sub _worksheet_message {
+    my ($self, $args) = @_;
+
+    return "Assisted collection? $args->{attributes}->{assisted_yn}\n\n" .
+           "Location of containers: $args->{attributes}->{location_of_containers}\n";
+}
+
 __PACKAGE__->run_if_script;

--- a/perllib/Open311/Endpoint/Integration/Whitespace.pm
+++ b/perllib/Open311/Endpoint/Integration/Whitespace.pm
@@ -82,7 +82,7 @@ sub post_service_request {
         uprn => $args->{attributes}->{uprn},
         service_item_name => $args->{attributes}->{service_item_name},
         worksheet_reference => $args->{attributes}->{fixmystreet_id},
-        worksheet_message => $args->{description},
+        worksheet_message => $self->_worksheet_message($args),
         assisted_yn => $args->{attributes}->{assisted_yn},
         location_of_containers => $args->{attributes}->{location_of_containers},
     });
@@ -92,6 +92,12 @@ sub post_service_request {
     );
 
     return $request;
+}
+
+sub _worksheet_message {
+    my ($self, $args) = @_;
+
+    return $args->{description};
 }
 
 1;

--- a/t/open311/endpoint/bexley.t
+++ b/t/open311/endpoint/bexley.t
@@ -224,4 +224,35 @@ subtest "POST update OK" => sub {
         } ], 'correct json returned';
 };
 
+subtest "Whitespace worksheets use Bexley's custom message" => sub {
+    my $ws = Test::MockModule->new('Integrations::Whitespace');
+    $ws->mock(CreateWorksheet => sub {
+        my ($self, $args) = @_;
+        is $args->{worksheet_message}, "Assisted collection? Yes\n\nLocation of containers: location of containers\n";
+        return 1001;
+    });
+    my $res = $endpoint->run_test_request(
+        POST => '/requests.json',
+        api_key => 'test',
+        service_code => 'Whitespace-WS1',
+        first_name => 'Bob',
+        last_name => 'Mould',
+        description => "This is the details",
+        lat => 51,
+        long => -1,
+        'attribute[uprn]' => 1000001,
+        'attribute[service_item_name]' => 'service item name',
+        'attribute[fixmystreet_id]' => 'fixmystreet id',
+        'attribute[assisted_yn]' => 'Yes',
+        'attribute[location_of_containers]' => 'location of containers',
+    );
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is_deeply decode_json($res->content),
+        [ {
+            "service_request_id" => "Whitespace-1001"
+        } ], 'correct json returned';
+};
+
 done_testing;


### PR DESCRIPTION
Instead of passing through the FMS description Bexley want to have details about whether a property is assisted and the location of the containers in the message that goes to Whitespace.

For https://3.basecamp.com/4020879/buckets/35109031/todos/7265317231

Part of https://github.com/mysociety/societyworks/issues/4206