### PR TITLE
[Hackney] Add Arcus passthrough for open311

### DIFF
--- a/conf/council-hackney_arcus.yml-example
+++ b/conf/council-hackney_arcus.yml-example
@@ -1,0 +1,2 @@
+endpoint: https://localhost:4000/
+api_key: 123

--- a/perllib/Open311/Endpoint/Integration/UK/Hackney/Arcus.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Hackney/Arcus.pm
@@ -13,7 +13,6 @@ package Open311::Endpoint::Integration::UK::Hackney::Arcus;
 
 use Moo;
 extends 'Open311::Endpoint::Integration::Passthrough';
-extends 'Open311::Endpoint::Integration::UK::Hackney::Base';
 
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;

--- a/perllib/Open311/Endpoint/Integration/UK/Hackney/Arcus.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Hackney/Arcus.pm
@@ -1,0 +1,24 @@
+=head1 NAME
+
+Open311::Endpoint::Integration::UK::Hackney::Arcus - Hackney passthrough for the Arcus backend
+
+=head1 SUMMARY
+
+This is the Hackney-specific Arcus integration. It is a standard
+Open311 server apart from it uses a different endpoint for updates.
+
+=cut
+
+package Open311::Endpoint::Integration::UK::Hackney::Arcus;
+
+use Moo;
+extends 'Open311::Endpoint::Integration::Passthrough';
+extends 'Open311::Endpoint::Integration::UK::Hackney::Base';
+
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'hackney_arcus';
+    return $class->$orig(%args);
+};
+
+1;

--- a/t/open311/endpoint/uk.t
+++ b/t/open311/endpoint/uk.t
@@ -53,10 +53,10 @@ test_multi(1, 'Open311::Endpoint::Integration::UK::Oxfordshire',
     'Open311::Endpoint::Integration::UK::Oxfordshire::AlloyV2' => 'oxfordshire_alloy_v2',
 );
 
-test_multi(1, 'Open311::Endpoint::Integration::UK::Hackney',
+test_multi(0, 'Open311::Endpoint::Integration::UK::Hackney',
     'Open311::Endpoint::Integration::UK::Hackney::Highways' => 'hackney_highways_alloy_v2',
     'Open311::Endpoint::Integration::UK::Hackney::Environment' => 'hackney_environment_alloy_v2',
-    'Open311::Endpoint::Integration::UK::Hackney::Arcus' => 'hackney_arcus',
+    #'Open311::Endpoint::Integration::UK::Hackney::Arcus' => 'hackney_arcus',
 
 );
 

--- a/t/open311/endpoint/uk.t
+++ b/t/open311/endpoint/uk.t
@@ -56,6 +56,8 @@ test_multi(1, 'Open311::Endpoint::Integration::UK::Oxfordshire',
 test_multi(1, 'Open311::Endpoint::Integration::UK::Hackney',
     'Open311::Endpoint::Integration::UK::Hackney::Highways' => 'hackney_highways_alloy_v2',
     'Open311::Endpoint::Integration::UK::Hackney::Environment' => 'hackney_environment_alloy_v2',
+    'Open311::Endpoint::Integration::UK::Hackney::Arcus' => 'hackney_arcus',
+
 );
 
 test_multi(1, 'Open311::Endpoint::Integration::UK::Buckinghamshire',


### PR DESCRIPTION
Adds passthrough for Arbus Open311

Society-servers has the config in the same branch name.

https://mysocietysupport.freshdesk.com/a/tickets/4052