### PR TITLE
[Echo] Strip suffixes defined by _

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -422,7 +422,11 @@ sub process_service_request_args {
     my $self = shift;
     my $args = shift;
 
-    my $event_type = $args->{service_code};
+    # Strip off any extra data added as a suffix in FMS config
+    # to reuse event type with multiple category names
+    # - ie 2951, 2951_1 and 2951_2 should be posted as 2951
+    # as that is the actual EventTypeId
+    my ($event_type) = split /_/, $args->{service_code};
     my $service = $args->{attributes}{service_id} || '';
     my $uprn = $args->{attributes}{uprn};
     my $client_reference = $self->client_reference($args);

--- a/t/open311/endpoint/echo.yml
+++ b/t/open311/endpoint/echo.yml
@@ -14,8 +14,11 @@ service_whitelist:
   Highways:
     2135: Flytipping
     2136: Flyposting
+    2137: 'General Litter'
   Superhighways:
     2135: Flytipping
+  Avenues:
+    2137_1: 'Local Litter'
 
 service_extra_data:
   2149-add:


### PR DESCRIPTION
If we have used a suffix in the categories of FMS to allow us to use one Event Type with separate category names, we strip the suffix before sending to Echo so the report is sent to the base Event type

https://github.com/mysociety/societyworks/issues/4365