### PR TITLE
[Surrey] Adds externalId for jobs and reports

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Boomi.pm
+++ b/perllib/Open311/Endpoint/Integration/Boomi.pm
@@ -177,12 +177,14 @@ sub _get_service_requests_for_integration_id {
 
     my @requests;
     for my $result (@$results) {
-        my ($id, $loggedDate, $e, $n) = do {
+        my $id = $result->{fmsReport}->{externalId};
+        my ($loggedDate, $e, $n) = do {
             if (my $enq = $result->{confirmEnquiry}) {
-                ($enq->{enquiryNumber}, $enq->{loggedDate}, $enq->{easting}, $enq->{northing});
+                ($enq->{loggedDate}, $enq->{easting}, $enq->{northing});
             } else {
+                $id = "JOB_" . $id;
                 my $job = $result->{confirmJob};
-                ("JOB_" . $job->{jobNumber}, $job->{entryDate}, $job->{easting}, $job->{northing});
+                ($job->{entryDate}, $job->{easting}, $job->{northing});
             }
         };
         $loggedDate = DateTime::Format::W3CDTF->parse_datetime($loggedDate);

--- a/t/open311/endpoint/surrey_boomi.t
+++ b/t/open311/endpoint/surrey_boomi.t
@@ -190,7 +190,6 @@ $lwp->mock(request => sub {
                 "results" => [
                     {
                         "confirmEnquiry" => {
-                            "enquiryNumber" => 136416,
                             "loggedDate" => "2024-07-26T08:42:52.000Z",
                             "statusCode" => "6000",
                             "subject" => {
@@ -202,6 +201,7 @@ $lwp->mock(request => sub {
                             "northing" => 164194
                         },
                         "fmsReport" => {
+                            "externalId" => 136416,
                             "status" => {
                                 "state" => "Open",
                                 "label" => "Allocated to a Highways Officer"
@@ -222,7 +222,6 @@ $lwp->mock(request => sub {
                     {
                         "confirmJob" => {
                             "entryDate" => "2024-07-26T07:46:33.000Z",
-                            "jobNumber" => 569081,
                             "statusCode" => "2000",
                             "priorityCode" => "HW09",
                             "jobType" => {
@@ -233,6 +232,7 @@ $lwp->mock(request => sub {
                             "northing" => 162735
                         },
                         "fmsReport" => {
+                            "externalId" => 569081,
                             "status" => {
                                 "state" => "Action scheduled",
                                 "label" => "Inspection scheduled"


### PR DESCRIPTION
Surrey will be sending an externalId specifically to be used for imported jobs and reports

https://3.basecamp.com/4020879/buckets/36546415/todos/7672617616#__recording_7683887161 https://mysociety.slack.com/archives/C06SKSH5KQT/p1722948392215939