### PR TITLE
[Confirm] Allow ignoring of enquiries in certain status

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -825,6 +825,7 @@ sub get_service_requests {
         my $code = $enquiry->{ServiceCode} . "_" . $enquiry->{SubjectCode};
         my $service = $services{$code};
         my $status = $self->reverse_status_mapping->{$enquiry->{EnquiryStatusCode}};
+        next if $status && $status eq 'IGNORE';
 
         unless ($service || ($service = $self->_find_wrapping_service($code, \@services))) {
             $self->logger->warn("no service for service code $code");


### PR DESCRIPTION
Fetched Enquiries will be skipped if their status
maps to IGNORE in reverse_status_mapping.

Matches behaviour of update fetching in 42f75f6b.