### PR TITLE
[Confirm] Log GraphQL errors.

### DIFF
--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -315,12 +315,17 @@ sub perform_request_graphql {
     my $body = {
         query => $query,
     };
+    my $encoded_body = encode_json($body);
 
-    $request->content(encode_json($body));
+    $request->content($encoded_body);
 
     my $response = $self->ua->request($request);
 
     my $content = decode_json($response->content);
+
+    if ($content->{errors} && @{$content->{errors}}) {
+        $self->logger->warn("Got errors in response to GraphQL query $encoded_body: " . $response->content);
+    }
 
     return $content;
 }

--- a/t/integrations/confirm.t
+++ b/t/integrations/confirm.t
@@ -1,0 +1,43 @@
+package Integrations::Confirm::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Integrations::Confirm';
+sub _build_config_file { path(__FILE__)->sibling("confirm.yml")->stringify }
+
+package main;
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::MockModule;
+use Test::Output;
+use HTTP::Response;
+use JSON::MaybeXS;
+
+BEGIN { $ENV{TEST_MODE} = 1; }
+
+my $lwp = Test::MockModule->new('LWP::UserAgent');
+
+$lwp->mock(request => sub {
+    return HTTP::Response->new(200, 'OK', [], encode_json({
+            data => {},
+            errors => [
+                {
+                    message => "Uh-oh spaghettio!",
+                }
+            ]
+        })
+    );
+});
+
+my $integration = Integrations::Confirm::Dummy->new;
+
+subtest "GraphQL errors are logged " => sub {
+    local $ENV{TEST_LOGGER} = 'warn';
+    stderr_like {
+        $integration->perform_request_graphql(type => 'job_types');
+    } qr/.*Uh-oh spaghettio!.*/, 'Got expected warning log for errors.';
+};
+
+done_testing;

--- a/t/integrations/confirm.yml
+++ b/t/integrations/confirm.yml
@@ -1,0 +1,2 @@
+graphql_url: "http://example.org/graphql"
+graphql_key: "key"


### PR DESCRIPTION
https://github.com/mysociety/societyworks/issues/4625

GraphQL returns an array of errors under an `errors` key, as per the [spec](https://spec.graphql.org/October2021/#sec-Errors).