### PR TITLE
[Bexley][WW] Fix value for credit card payments send to Agile

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Agile.pm
+++ b/perllib/Open311/Endpoint/Integration/Agile.pm
@@ -54,9 +54,9 @@ use constant SERVICE_TO_SUB_MAPPING => {
 };
 
 use constant PAYMENT_METHOD_MAPPING => {
-    credit_card  => 'CREDITCARD',
+    credit_card  => 'CREDITDCARD',
     direct_debit => 'DIRECTDEBIT',
-    csc => 'CREDITCARD',
+    csc => 'CREDITDCARD',
 };
 
 sub get_integration {


### PR DESCRIPTION
There was a typo in the value for credit cards and CSC, it's now CREDITDCARD, with the D, which matches the [API docs](https://docs.google.com/document/d/1gPBFFXGMXEun8qTxGkjL2vc0dAKw09Ft/edit).

Added some tests for the payment method, which feels quite verbose compared to the code change, but think it covers all cases.

For [this Basecamp discussion](https://3.basecamp.com/4020879/buckets/40373795/todos/8407498579#__recording_8489124569)