### PR TITLE
Convert check-endpoints to an Icinga check

### DIFF
--- a/bin/check-endpoints
+++ b/bin/check-endpoints
@@ -3,6 +3,8 @@
 use strict;
 use warnings;
 use v5.14;
+use lib '/usr/lib/nagios/plugins';
+use utils qw(%ERRORS);
 
 BEGIN {
     use File::Basename qw(dirname);
@@ -21,4 +23,25 @@ GetOptions (
 
 my $uk = Open311::Endpoint::Integration::UK->new;
 
-$uk->check_endpoints($verbose);
+my @expiring = $uk->check_endpoints($verbose);
+
+if (@expiring) {
+    if ($verbose) {
+        # We've got everything, let's just check if anything is expiring.
+        my $ret = "OK";
+        foreach (@expiring) {
+            next if $_ =~ /will not expire/;
+            $ret = "WARNING";
+        }
+        print "${ret}: verbose flag passed - printing all:\n";
+        print join('\n', @expiring), "\n";
+        exit $ERRORS{$ret};
+    } else {
+        print "WARNING: Certificates expiring within the next week:\n";
+        print join('\n', @expiring), "\n";
+        exit $ERRORS{WARNING};
+    }
+}
+
+print "OK: no endpoint certificates due to expire in the next week.\n";
+exit $ERRORS{OK};

--- a/perllib/Open311/Endpoint/Integration/UK.pm
+++ b/perllib/Open311/Endpoint/Integration/UK.pm
@@ -170,12 +170,14 @@ sub check_endpoints {
     foreach (grep { $_ } @urls) {
         $hosts{URI->new($_)->host} = 1;
     }
+    my @checks;
     foreach (sort keys %hosts) {
         next if $_ eq 'fixwstest.bromley.gov.uk'; # Not currently working, only test instance
         my $check = `openssl s_client -connect $_:443 < /dev/null 2>/dev/null| openssl x509 -checkend 604800 -noout`;
         next if $check =~ /will not expire/ && !$verbose;
-        print "$_: $check";
+        push @checks, "$_: $check";
     }
+    return @checks;
 }
 
 __PACKAGE__->run_if_script;


### PR DESCRIPTION
Rather than printing the output from the checks, return an array, then in the check script format this using the nagios plugin library.