### PR TITLE
[Merton][Echo] Amend Bulky collection on same date

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/Echo.pm
@@ -538,4 +538,27 @@ sub update_event_payment {
     $args->{description} = ''; # Blank out so nothing sent to Echo now
 }
 
+=head2
+
+When a bulky booking has been updated, but the booking day hasn't changed,
+we want to update the current booking in place.
+
+=cut
+
+sub update_event_bulky_booking {
+    my ($self, $args) = @_;
+
+    my $integ = $self->get_integration;
+    my $event = $integ->GetEvent($args->{service_request_id}, $args->{id_type});
+    my $data = [ ];
+    foreach (@$fields) {
+    push @$data,
+                { id => 57236, value => $_->{notes} },
+                { id => 57237, value => $_->{items} };
+                { id => 57238, value => $_->{} };
+    };
+    $integ->UpdateEvent({ id => $event->{Id}, data => $data });
+    $args->{description} = ''; # Blank out so nothing sent to Echo now
+}
+
 1;

--- a/perllib/Open311/Endpoint/Integration/UK/Merton/Echo.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Merton/Echo.pm
@@ -25,6 +25,8 @@ around BUILDARGS => sub {
 
 has cancel_actiontype_id => ( is => 'ro', default => 8 );
 
+has bulky_amend_actiontype_id => ( is => 'ro', default => 12 );
+
 =head2 process_service_request_args
 
 If we are sending an assisted collection event, we need to set some special

--- a/perllib/Open311/Endpoint/Role/SLWP.pm
+++ b/perllib/Open311/Endpoint/Role/SLWP.pm
@@ -66,6 +66,12 @@ around post_service_request_update => sub {
         $args->{datatype_id} = 0;
     }
 
+    if ($args->{description} =~ /Amend Bulky collection/) {
+        $args->{actiontype_id} = $class->bulky_amend_actiontype_id;
+        use Data::Dumper; warn Dumper $args;
+        $class->update_event_bulky_booking($args, { ref => $ref, amount => $amount });
+    }
+
     my $result = $class->$orig($args);
 
     return $result;


### PR DESCRIPTION
When amending a bulky booking but keeping the same collection date, don't cancel the report.

Receive data from FMS and update the Event with
the changed details.

This isn't quite complete as not clear on the fields that need to be set for the Event and how they are updated rather than overwritten...hopefully the mechanics are ok though.

https://github.com/mysociety/societyworks/issues/4732