### PR TITLE
[Gloucester] Send through priority and target date 

### DIFF
--- a/perllib/FixMyStreet/WorkingDays.pm
+++ b/perllib/FixMyStreet/WorkingDays.pm
@@ -1,0 +1,107 @@
+# Copy of package from FMS repo
+package FixMyStreet::WorkingDays;
+
+use Moo;
+
+=head1 FixMyStreet::WorkingDays
+
+Given a list of public holiday dates, creates an object that can be used to
+add/subtract days from a date, only counting working days (excluding public
+holidays and weekends or Sundays).
+
+=over
+
+=cut
+
+has public_holidays => (
+    is => 'ro',
+    default => sub { [] },
+    coerce => sub {
+        return { map { $_ => 1 } @{$_[0]} };
+    },
+);
+
+# Set to true if Saturdays are a working day
+has saturdays => (
+    is => 'ro',
+    default => 0,
+);
+
+=item add_days
+
+Given a DateTime object and a number of days, returns a new DateTime object
+that many working days (excluding public holidays and weekends) later.
+
+=cut
+
+sub add_days {
+    my ( $self, $dt, $days, $subtract ) = @_;
+    $dt = $dt->clone;
+    while ( $days > 0 ) {
+        $dt->add ( days => $subtract ? -1 : 1 );
+        next if $self->is_non_working_day($dt);
+        $days--;
+    }
+    return $dt;
+}
+
+=item sub_days
+
+Given a DateTime object and a number of days, returns a new DateTime object
+that many working days (excluding public holidays and weekends) earlier.
+
+=cut
+
+sub sub_days {
+    my $self = shift;
+    return $self->add_days(@_, 1);
+}
+
+=item is_non_working_day
+
+Given a DateTime object, return true if it's a non-working day.
+
+=cut
+
+sub is_non_working_day {
+    my ( $self, $dt ) = @_;
+    return $self->is_public_holiday($dt) || $self->is_sunday($dt) || (!$self->saturdays && $self->is_weekend($dt));
+}
+
+=item is_public_holiday
+
+Given a DateTime object, return true if it is a public holiday.
+
+=cut
+
+sub is_public_holiday {
+    my ($self, $dt) = @_;
+    return $self->public_holidays->{$dt->ymd};
+}
+
+=item is_sunday
+
+Given a DateTime object, return true if it is a Sunday.
+
+=cut
+
+sub is_sunday {
+    my ($self, $dt) = @_;
+    return $dt->dow == 7;
+}
+
+=item is_weekend
+
+Given a DateTime object, return true if it is a weekend.
+
+=cut
+
+sub is_weekend {
+    my ($self, $dt) = @_;
+    return $dt->dow > 5;
+}
+
+1;
+
+=back
+

--- a/perllib/Open311/Endpoint/Integration/UK/Gloucester.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Gloucester.pm
@@ -31,6 +31,8 @@ sub process_attributes {
     my $attributes = $self->SUPER::process_attributes($args);
     push @$attributes, @question_attributes if @question_attributes;
 
+    $self->_populate_priority_and_target_date($attributes, $service_code);
+
     $self->_populate_category_and_group_attr(
         $attributes,
         $category_code,
@@ -69,6 +71,23 @@ sub _munge_question_args {
     }
 
     return @q_attributes;
+}
+
+sub _populate_priority_and_target_date {
+    my ($self, $attr, $category) = @_;
+    my $mapping = $self->config->{category_attribute_mapping};
+
+    # Priority
+    my $priority_value = $self->config->{question_mapping}{priority}{$category};
+    if ($priority_value) {
+        # It has a default, so change that
+        foreach (@$attr) {
+            if ($_->{attributeCode} eq $mapping->{priority}) {
+                $_->{value} = [$priority_value];
+                last;
+            }
+        }
+    }
 }
 
 sub _populate_category_and_group_attr {

--- a/t/open311/endpoint/gloucester_alloy.t
+++ b/t/open311/endpoint/gloucester_alloy.t
@@ -16,6 +16,8 @@ around BUILDARGS => sub {
 };
 has integration_class => (is => 'ro', default => 'Integrations::AlloyV2::Dummy');
 
+has '+testing' => ( default => 1 );
+
 package main;
 
 use strict;
@@ -34,6 +36,12 @@ BEGIN { $ENV{TEST_MODE} = 1; }
 my (@sent);
 
 my $endpoint = Open311::Endpoint::Integration::UK::Dummy->new;
+
+my $lwp = Test::MockModule->new('LWP::UserAgent');
+$lwp->mock('get', sub {
+    my ($self, $url) = @_;
+    return HTTP::Response->new(200, 'OK', [], '{}');
+});
 
 my $integration = Test::MockModule->new('Integrations::AlloyV2');
 $integration->mock('api_call', sub {
@@ -234,6 +242,10 @@ Other',
                     value => ['61daed49fdc7a101544177de'],
                 },
                 {   attributeCode =>
+                        'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
+                    value => '2025-04-02',
+                },
+                {   attributeCode =>
                         'attributes_defectsReportedDate',
                     value => '2025-04-01T12:00:00Z',
                 },
@@ -303,6 +315,10 @@ Yes',
                     value => ['61ba198c7148450165fff23f'],
                 },
                 {   attributeCode =>
+                        'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
+                    value => '2025-06-24',
+                },
+                {   attributeCode =>
                         'attributes_defectsReportedDate',
                     value => '2025-04-01T12:00:00Z',
                 },
@@ -368,6 +384,10 @@ Yes',
                     value => ['61b9e1ccfb9e760158036bc1'],
                 },
                 {   attributeCode =>
+                        'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
+                    value => '2025-04-29',
+                },
+                {   attributeCode =>
                         'attributes_defectsReportedDate',
                     value => '2025-04-01T12:00:00Z',
                 },
@@ -427,6 +447,10 @@ Yes',
                 {   attributeCode =>
                         'attributes_customerContactSubCategory_630e951646f558015aa26b41',
                     value => ['61b9e1127148450165fd145f'],
+                },
+                {   attributeCode =>
+                        'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
+                    value => '2025-04-29',
                 },
                 {   attributeCode =>
                         'attributes_defectsReportedDate',

--- a/t/open311/endpoint/gloucester_alloy.t
+++ b/t/open311/endpoint/gloucester_alloy.t
@@ -221,6 +221,10 @@ subtest 'send new report to Alloy' => sub {
 Type of animal?
 Other',
                 },
+                { attributeCode =>
+                        'attributes_customerContactPriorities_630e8d78afc533014f6cce97',
+                    value => ['61827451d1b798015bba7e4c']
+                },
                 {   attributeCode =>
                         'attributes_customerContactServiceArea_630e905e1aff30015017e892',
                     value => ['630e8f0b3c0f4b0153a2ff36'],
@@ -286,6 +290,10 @@ Other',
 Did you witness the dog fouling?
 Yes',
                 },
+                { attributeCode =>
+                        'attributes_customerContactPriorities_630e8d78afc533014f6cce97',
+                    value => ['67d12b067e3fda851c204b2f']
+                },
                 {   attributeCode =>
                         'attributes_customerContactServiceArea_630e905e1aff30015017e892',
                     value => ['630e8f0b3c0f4b0153a2ff36'],
@@ -347,6 +355,10 @@ Yes',
                         'attributes_customerContactCustomerComments_630e97d11aff300150181403',
                     value => 'description',
                 },
+                { attributeCode =>
+                        'attributes_customerContactPriorities_630e8d78afc533014f6cce97',
+                    value => ['67d12b067e3fda851c204b2f']
+                },
                 {   attributeCode =>
                         'attributes_customerContactServiceArea_630e905e1aff30015017e892',
                     value => ['630e8f183c0f4b0153a2ff5c'],
@@ -403,6 +415,10 @@ Yes',
                 {   attributeCode =>
                         'attributes_customerContactCustomerComments_630e97d11aff300150181403',
                     value => 'description',
+                },
+                { attributeCode =>
+                        'attributes_customerContactPriorities_630e8d78afc533014f6cce97',
+                    value => ['61827451d1b798015bba7e4c']
                 },
                 {   attributeCode =>
                         'attributes_customerContactServiceArea_630e905e1aff30015017e892',

--- a/t/open311/endpoint/gloucester_alloy.yml
+++ b/t/open311/endpoint/gloucester_alloy.yml
@@ -23,6 +23,7 @@ category_attribute_mapping: {
   category: 'attributes_customerContactCategory_630e927746f558015aa26062',
   service_area: 'attributes_customerContactServiceArea_630e905e1aff30015017e892',
   priority: 'attributes_customerContactPriorities_630e8d78afc533014f6cce97',
+  target_date: 'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
 }
 
 # Inspection updates
@@ -175,6 +176,13 @@ question_mapping: {
   'priority': {
     'Dead animal that needs removing': '61827451d1b798015bba7e4c',
     'Overflowing litter bin': '61827451d1b798015bba7e4c',
+  },
+
+  'target_date_sla': {
+    'Dead animal that needs removing': { "days": 1 },
+    'Damaged dog bin': { "days": 20 },
+    'Overflowing litter bin': { "days": 20 },
+    'Dog fouling': { "weeks": 12 },
   },
 }
 

--- a/t/open311/endpoint/gloucester_alloy.yml
+++ b/t/open311/endpoint/gloucester_alloy.yml
@@ -9,6 +9,10 @@ created_datetime_attribute_id: 'attributes_defectsReportedDate'
 resource_attachment_attribute_id: 'attributes_filesAttachableAttachments'
 geometry_attribute: 'attributes_itemsGeometry'
 
+resource_attribute_defaults: {
+  'attributes_customerContactPriorities_630e8d78afc533014f6cce97': ['67d12b067e3fda851c204b2f'],
+}
+
 request_to_resource_attribute_mapping: {
   fixmystreet_id: 'attributes_customerContactCRMReference_630e97373c0f4b0153a32650',
   description: 'attributes_customerContactCustomerComments_630e97d11aff300150181403',
@@ -18,6 +22,7 @@ category_attribute_mapping: {
   subcategory: 'attributes_customerContactSubCategory_630e951646f558015aa26b41',
   category: 'attributes_customerContactCategory_630e927746f558015aa26062',
   service_area: 'attributes_customerContactServiceArea_630e905e1aff30015017e892',
+  priority: 'attributes_customerContactPriorities_630e8d78afc533014f6cce97',
 }
 
 # Inspection updates
@@ -165,6 +170,11 @@ question_mapping: {
     'Small wild animal (e.g. birds, mice)':  5d8a504dca31500b4030ecaa,
     'Large wild animal (e.g. swan, badger)': 5d8a50c4ca31500a9469ab9d,
     'Other':                                 5d8a50dfca31500a9469aba2,
+  },
+
+  'priority': {
+    'Dead animal that needs removing': '61827451d1b798015bba7e4c',
+    'Overflowing litter bin': '61827451d1b798015bba7e4c',
   },
 }
 


### PR DESCRIPTION
Bit of duplication of FMS working day code, but seemed easier to hold it all within open311-adapter.

Server config would be as in tests, but for all the categories that needed to be High and with all the target SLAs.

Fixes https://github.com/mysociety/societyworks/issues/5018