### PR TITLE
[Gloucester] Set target date to end of day.

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/Gloucester.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Gloucester.pm
@@ -100,13 +100,16 @@ sub _populate_priority_and_target_date {
     my $sla = $self->config->{question_mapping}{target_date_sla}{$category};
     die "No target date entry found for $category" unless $sla;
     my $date;
-    my $now = DateTime->now(time_zone => "Europe/London");
+    my $formatter = DateTime::Format::W3CDTF->new(strict => 1);
+    my $now = DateTime->now(time_zone => "Europe/London", formatter => $formatter);
     if ($sla->{days}) {
         my $wd = FixMyStreet::WorkingDays->new(public_holidays => $self->public_holidays());
-        $date = $wd->add_days($now, $sla->{days})->date;
+        $date = $wd->add_days($now, $sla->{days});
     } elsif ($sla->{weeks}) {
-        $date = $now->add(weeks => $sla->{weeks})->date;
+        $date = $now->add(weeks => $sla->{weeks});
     }
+    $date->set(hour => 23, minute => 59, second => 59)->set_time_zone('UTC');
+
     push @$attr, { attributeCode => $mapping->{target_date}, value => $date };
 }
 

--- a/t/open311/endpoint/gloucester_alloy.t
+++ b/t/open311/endpoint/gloucester_alloy.t
@@ -243,7 +243,7 @@ Other',
                 },
                 {   attributeCode =>
                         'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
-                    value => '2025-04-02',
+                    value => '2025-04-02T22:59:59Z',
                 },
                 {   attributeCode =>
                         'attributes_defectsReportedDate',
@@ -316,7 +316,7 @@ Yes',
                 },
                 {   attributeCode =>
                         'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
-                    value => '2025-06-24',
+                    value => '2025-06-24T22:59:59Z',
                 },
                 {   attributeCode =>
                         'attributes_defectsReportedDate',
@@ -385,7 +385,7 @@ Yes',
                 },
                 {   attributeCode =>
                         'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
-                    value => '2025-04-29',
+                    value => '2025-04-29T22:59:59Z',
                 },
                 {   attributeCode =>
                         'attributes_defectsReportedDate',
@@ -450,7 +450,7 @@ Yes',
                 },
                 {   attributeCode =>
                         'attributes_customerContactTargetDate_63105e3a46f558015ab4c576',
-                    value => '2025-04-29',
+                    value => '2025-04-29T22:59:59Z',
                 },
                 {   attributeCode =>
                         'attributes_defectsReportedDate',


### PR DESCRIPTION
For https://3.basecamp.com/4020879/buckets/38208405/todos/8821272844
Providing a full datetime rather than only a date (that is defaulting to midnight UTC at start of day).