### PR TITLE
[Aberdeenshire] Ignore defects linked to our own enquiries; only fetch defects with target date.

### DIFF
--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -154,6 +154,17 @@ has completion_statuses => (
     default => sub { $_[0]->config->{completion_statuses} || [] }
 );
 
+=head2 external_system_number
+
+A code to use to mark enquiries we submit as coming from us; with this set,
+we also send the FMS ID through as the external system reference.
+
+=cut
+
+has external_system_number => (
+    is => 'lazy',
+    default => sub { $_[0]->config->{external_system_number} }
+);
 
 =head2 base_url
 
@@ -541,6 +552,11 @@ sub defects_graphql_query { # XXX factor together with jobs?
     ){
         code
     }
+    enquiries {
+        centralEnquiry {
+            externalSystemNumber
+        }
+    }
     job {
       jobNumber
       currentStatusLog {
@@ -792,8 +808,8 @@ sub NewEnquiry {
         $enq{CentralAssetId} = $args->{central_asset_id};
     }
 
-    if ($args->{external_system_number}) {
-        $enq{ExternalSystemNumber} = $args->{external_system_number};
+    if ($self->external_system_number) {
+        $enq{ExternalSystemNumber} = $self->external_system_number;
         $enq{ExternalSystemReference} = $args->{attributes}->{fixmystreet_id};
     }
     if (my $code = $self->service_enquiry_class_code($service_code)) {

--- a/perllib/Integrations/Confirm.pm
+++ b/perllib/Integrations/Confirm.pm
@@ -536,6 +536,7 @@ sub defects_graphql_query { # XXX factor together with jobs?
                 greaterThanEquals: "$start_date"
                 lessThanEquals: "$end_date"
             }
+            targetDate: { hasValue: true }
         }
   ) {
     defectNumber


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5055
For https://github.com/mysociety/societyworks/issues/5042

Didn't seem worth adding a test, because all that would be changing is the mocked returned data, so have to test it works outside anyway (this appears to be the correct formulation hopefully, used for enquiries commit for the number, and network panel of UI for the target date boolean).