### PR TITLE
[Bartec] Add ability to update status and extra data.

### DIFF
--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -75,13 +75,8 @@ has status_map => (
         my $statuses = $self->ServiceRequests_Statuses_Get;
         my %map;
         for my $status ( @{ $statuses->{ServiceStatus} } ) {
-            $map{ $status->{ServiceTypeID} } ||= {};
-            my $fms_status = $self->config->{status_map}->{ $status->{Status} };
-            $fms_status = 'open' if $status->{Status} eq 'PENDING';
-            next unless $fms_status;
-            $map{ $status->{ServiceTypeID} }->{$fms_status} = $status->{ID};
+            $map{$status->{ServiceTypeID}}->{$status->{Status}} = $status->{ID};
         }
-
         return \%map;
     }
 );
@@ -230,6 +225,12 @@ sub _methods {
             namespace  => 'http://bartec-systems.com/',
             parameters => [],
         },
+        'ServiceRequest_Update' => {
+            endpoint   => $self->collective_endpoint,
+            soapaction => 'http://bartec-systems.com/ServiceRequest_Update',
+            namespace  => 'http://bartec-systems.com/',
+            parameters => [],
+        },
         'System_ExtendedDataDefinitions_Get' => {
             endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/System_ExtendedDataDefinitions_Get',
@@ -252,10 +253,7 @@ sub _methods {
             endpoint   => $self->collective_endpoint,
             soapaction => 'http://bartec-systems.com/ServiceRequests_Detail_Get',
             namespace  => 'http://bartec-systems.com/',
-            parameters => [
-                SOAP::Data->new(name => 'token', type => 'string'),
-                SOAP::Data->new(name => 'ServiceCode', type => 'string'),
-            ],
+            parameters => [],
         },
         'ServiceRequests_Statuses_Get' => {
             endpoint   => $self->collective_endpoint,
@@ -424,7 +422,9 @@ sub ServiceRequest_Create {
     my $dt = DateTime->now(time_zone => 'Europe/London');
     my $time = DateTime::Format::W3CDTF->new->format_datetime($dt);
 
-    my $status_id = $self->status_map->{$values->{service_code}}->{open};
+    my $bartec_status = $self->config->{forward_status_map}->{OPEN};
+    die "There must be an open forward status mapping" unless $bartec_status;
+    my $status_id = $self->status_map->{$values->{service_code}}->{$bartec_status};
 
     my %req = (
         token => $self->token,
@@ -451,18 +451,10 @@ sub ServiceRequest_Create {
         },
     );
 
-    if ( my $extended = $self->get_extended_data ) {
-        if ( my $data = $self->service_extended_data_map->{ $values->{service_code} } ) {
-            my @data;
-            for my $v ( @$data ) {
-                push @data, {
-                    FieldName => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd' }, value => $v->{code} },
-                    FieldValue => { attr => { xmlns => 'http://www.bartec-systems.com/ServiceRequest_Create.xsd' }, value => SOAP::Utils::encode_data($values->{attributes}->{$v->{code}}) },
-                } if $values->{attributes}->{$v->{code}};
-            }
-            $req{extendedData} = { ServiceRequest_CreateServiceRequest_CreateFields => \@data } if @data;
-        }
-    }
+    $self->_add_extended_data($values, \%req,
+        'ServiceRequest_CreateServiceRequest_CreateFields',
+        'http://www.bartec-systems.com/ServiceRequest_Create.xsd',
+    );
 
     my %data = (
         %{ $self->service_defaults->{$values->{service_code} } },
@@ -474,17 +466,33 @@ sub ServiceRequest_Create {
     return $self->_wrapper('ServiceRequest_Create', 1, $elem);
 }
 
+sub _add_extended_data {
+    my ($self, $values, $req, $key, $ns) = @_;
+
+    if ( my $extended = $self->get_extended_data ) {
+        if ( my $data = $self->service_extended_data_map->{ $values->{service_code} } ) {
+            my @data;
+            for my $v ( @$data ) {
+                push @data, {
+                    FieldName => { attr => { xmlns => $ns }, value => $v->{code} },
+                    FieldValue => { attr => { xmlns => $ns }, value => SOAP::Utils::encode_data($values->{attributes}->{$v->{code}}) },
+                } if $values->{attributes}->{$v->{code}};
+            }
+            $req->{extendedData} = { $key => \@data } if @data;
+        }
+    }
+}
+
 sub ServiceRequest_Status_Set {
     my ($self, $sr, $status) = @_;
 
     my $service_code = $sr->{ServiceRequest}{ServiceCode};
     my $service_type_id = $sr->{ServiceRequest}{ServiceType}{ID};
-
-    my $statuses = $self->ServiceRequests_Statuses_Get;
     # e.g. 2388 for OPEN Bulky Collection
-    my ($open_status) = grep { $_->{Status} eq $status && $_->{ServiceTypeID} eq $service_type_id } @{ $statuses->{ServiceStatus} };
+    $status = $self->status_map->{$service_type_id}{$status};
+    return unless $status;
 
-    return $self->_wrapper('ServiceRequest_Status_Set', 0, $service_code, $open_status->{ID}, '');
+    return $self->_wrapper('ServiceRequest_Status_Set', 0, $service_code, $status, '');
 }
 
 sub ServiceRequest_Document_Create {
@@ -531,6 +539,24 @@ sub ServiceRequest_Note_Create {
     my $elem = SOAP::Data->value( make_soap_structure( %req ) );
 
     return $self->_wrapper('ServiceRequest_Note_Create', 1, $elem);
+}
+
+sub ServiceRequest_Update {
+    my ($self, $sr, $values) = @_;
+
+    my %req = (
+        token => $self->token,
+        serviceCode => $sr,
+        serviceLocationDescription => '', # Needed otherwise it fails
+    );
+
+    $self->_add_extended_data($values, \%req,
+        'ServiceRequest_UpdateServiceRequest_UpdateFieldFields',
+        'http://www.bartec-systems.com/ServiceRequests_Get.xsd',
+    );
+
+    my $elem = SOAP::Data->value( make_soap_structure( %req ) );
+    return $self->_wrapper('ServiceRequest_Update', 1, $elem);
 }
 
 sub ServiceRequests_Updates_Get {
@@ -600,7 +626,12 @@ sub get_extended_data {
 
 sub ServiceRequests_Detail_Get {
     my $self = shift;
-    return $self->_wrapper('ServiceRequests_Detail_Get', 0, @_);
+    my %req = (
+        token => $self->token,
+        ServiceCodes => { string => $_[0] },
+    );
+    my $elem = SOAP::Data->value( make_soap_structure( %req ) );
+    return $self->_wrapper('ServiceRequests_Detail_Get', 1, $elem);
 }
 
 sub ServiceRequests_Statuses_Get {

--- a/perllib/Open311/Endpoint/Integration/Bartec.pm
+++ b/perllib/Open311/Endpoint/Integration/Bartec.pm
@@ -413,6 +413,39 @@ sub distance_haversine {
     return $d;
 }
 
+sub post_service_request_update {
+    my ($self, $args) = @_;
+
+    my $integ = $self->get_integration;
+    my $conf = $integ->config;
+
+    # Update Bartec status
+    if (my $bartec_status = $conf->{forward_status_map}->{$args->{status}}) {
+        my $sr = {
+            ServiceRequest => {
+                ServiceCode => $args->{service_request_id},
+                ServiceType => { ID => $args->{service_code} },
+            }
+        };
+        my $res = $integ->ServiceRequest_Status_Set($sr, $bartec_status);
+        if ($res->{Errors}{Result}) {
+            $self->logger->warn("failed to update status on $args->{service_request_id}: $res->{Errors}->{Message}");
+        }
+    }
+
+    # Update Bartec extra data
+    my $res = $integ->ServiceRequest_Update($args->{service_request_id}, $args);
+    if ($res->{Errors}{Result}) {
+        $self->logger->warn("failed to update extra data on $args->{service_request_id}: $res->{Errors}->{Message}");
+    }
+
+    return Open311::Endpoint::Service::Request::Update::mySociety->new(
+        service_request_id => $args->{service_request_id},
+        status => lc $args->{status},
+        update_id => 'BLANK',
+    );
+}
+
 sub get_service_request_updates {
     my ($self, $args) = @_;
 

--- a/perllib/Open311/Endpoint/Integration/Bartec.pm
+++ b/perllib/Open311/Endpoint/Integration/Bartec.pm
@@ -490,10 +490,11 @@ sub get_service_request_updates {
         my $entries = $self->get_integration->_coerce_to_array( $history, 'ServiceRequest_History' );
 
         for my $entry ( @$entries ) {
-            my $status = $self->_get_update_status($entry);
+            my ($status, $external_status) = $self->_get_update_status($entry);
             next unless $status; # No status, nothing to do
             my %args = (
                 status => $status,
+                $external_status ? ( external_status_code => $external_status ) : (),
                 update_id => $entry->{id},
                 service_request_id => $entry->{ServiceCode},
                 description => '',
@@ -521,7 +522,7 @@ sub _get_update_status {
         $status = $mapped if $mapped;
     }
 
-    return $status;
+    return ($status, $code);
 }
 
 sub get_service_requests {

--- a/t/integrations/bartec.t
+++ b/t/integrations/bartec.t
@@ -2,21 +2,12 @@ package Integrations::Bartec::Dummy;
 use Path::Tiny;
 use Moo;
 extends 'Integrations::Bartec';
-sub _build_config_file { path(__FILE__)->sibling('bartec.yml')->stringify }
+sub _build_config_file { path(__FILE__)->parent->parent->child('open311', 'endpoint', 'bartec.yml')->stringify }
 
-sub collective_endpoint { 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx' }
+package main;
 
-sub auth_endpoint { 'https://collapi.bartec-systems.com/CollAuth/Authenticate.asmx' }
-
-sub get_integration {
-    my $self = shift;
-    my $integ = Integrations::Bartec::Dummy->new;
-    $integ->config_filename('dummy');
-    return $integ;
-}
-my $integration = get_integration();
-
-use strict; use warnings;
+use strict;
+use warnings;
 
 use Test::More;
 use Test::LongString;
@@ -24,6 +15,14 @@ use Test::MockModule;
 use Test::Output;
 
 BEGIN { $ENV{TEST_MODE} = 1; }
+
+my $integration = get_integration();
+
+sub get_integration {
+    my $self = shift;
+    my $integ = Integrations::Bartec::Dummy->new;
+    return $integ;
+}
 
 sub gen_full_response {
     my $append = shift(@_);

--- a/t/open311/endpoint/bartec.t
+++ b/t/open311/endpoint/bartec.t
@@ -110,6 +110,7 @@ my %responses = (
     ServiceRequests_Notes_Types_Get => path(__FILE__)->parent(1)->realpath->child('xml/bartec/servicerequests_notes_types_get.xml')->slurp,
     ServiceRequest_Note_Create => \&ServiceRequest_Note_Create,
     System_ExtendedDataDefinitions_Get => path(__FILE__)->parent(1)->realpath->child('xml/bartec/extended_definitions.xml')->slurp,
+    ServiceRequest_Update => '',
 );
 
 sub gen_full_response {
@@ -134,7 +135,6 @@ my $transport = Test::MockModule->new('SOAP::Transport::HTTP::Client', no_auto =
 $transport->mock(send_receive => sub {
         my $self = shift;
         my %args = @_;
-
 
         (my $action = $args{action}) =~ s#http://bartec-systems.com/##;
         $action =~ s/"//g;
@@ -1385,6 +1385,34 @@ subtest 'fetch_requests with no results' => sub {
 
 
     is_deeply decode_json($res->content), [ ], 'empty list of requests';
+};
+
+subtest 'updates' => sub {
+    my $res = $endpoint->run_test_request(
+        POST => '/servicerequestupdates.json',
+        api_key => 'test',
+        update_id => '123',
+        updated_datetime => '2026-02-20T12:00:00Z',
+        service_code => 1,
+        service_request_id => '1001',
+        status => 'IN_PROGRESS',
+        description => '',
+    );
+
+    my $sr_update = SOAP::Deserializer->deserialize( $sent{ServiceRequest_Update} );
+    is_deeply $sr_update->body->{ServiceRequest_Update}, {
+        token => 'ABC=',
+        serviceCode => '1001',
+        serviceLocationDescription => '',
+    }, "correct request";
+
+    my $status_set = SOAP::Deserializer->deserialize( $sent{ServiceRequest_Status_Set} );
+    is_deeply $status_set->body->{ServiceRequest_Status_Set}, {
+        token => 'ABC=',
+        ServiceCode => '1001',
+        StatusID => 2278,
+        Comments => '',
+    }, "correct request";
 };
 
 done_testing;

--- a/t/open311/endpoint/bartec.t
+++ b/t/open311/endpoint/bartec.t
@@ -1278,6 +1278,7 @@ subtest 'fetch updates' => sub {
             update_id => 228028,
             service_request_id => 'SR00051624',
             status => 'closed',
+            external_status_code => 'UNMAPPED',
             updated_datetime => '2020-06-17T09:59:26+01:00',
             description => '',
             media_url => '',

--- a/t/open311/endpoint/bartec.yml
+++ b/t/open311/endpoint/bartec.yml
@@ -46,6 +46,13 @@ field_defaults:
   Source: FixMyStreet
   ReporterType: Public
 
+forward_status_map:
+  OPEN: OPEN
+  INVESTIGATING: PENDING
+  IN_PROGRESS: IN PROGRESS
+  CLOSED: CLOSED
+  CANCELLED: CANCELLED
+
 status_map:
   OPEN: open
   PENDING: investigating


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5312

Adds a forward_status_map to cover state changes from FMS to Bartec (and creating new report uses that rather than an inverted status_map (which is used for the other way)) using status set, and updates the service request with any extra data provided.