### PR TITLE
[Rutland][SalesForce] Rutland salesforce refresh

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/Rutland/SalesForce.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Rutland/SalesForce.pm
@@ -20,6 +20,12 @@ has jurisdiction_id => (
     default => 'rutland_salesforce',
 );
 
+has 'whitelist' => (
+    is => 'ro',
+    is => 'lazy',
+    default => sub { shift->get_integration->config->{whitelist} || {} }
+);
+
 sub reverse_status_mapping {
     my ($self, $status) = @_;
 
@@ -196,6 +202,7 @@ sub services {
     my ($self, $args) = @_;
 
     my @services = $self->get_integration->get_services($args);
+    @services = grep { $self->whitelist->{ $_->{name} } || $_->{hasChildren} eq 'true' } @services;
 
     my %service_lookup = map { $_->{serviceid} => $_ } @services;
 
@@ -230,6 +237,7 @@ sub service {
 
     my $meta = $self->get_integration->get_service($id, $args);
     my @services = $self->get_integration->get_services($args);
+    @services = grep { $self->whitelist->{ $_->{name} } || $_->{hasChildren} eq 'true' } @services;
 
     my %service_lookup = map { $_->{serviceid} => $_ } @services;
     my $srv = $service_lookup{$id};

--- a/perllib/Open311/Endpoint/Integration/UK/Rutland/SalesForce.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Rutland/SalesForce.pm
@@ -280,23 +280,22 @@ sub service {
     }
 
     my %options = (
+        code => 'notice',
         required => 0,
         variable => 0,
         datatype => 'string',
-        automated => 'server_set',
     );
 
-    push @{ $service->attributes }, Open311::Endpoint::Service::Attribute->new(
-        code => 'hint',
-        description => $hint,
-        %options,
-    );
-
-    push @{ $service->attributes }, Open311::Endpoint::Service::Attribute->new(
-        code => 'group_hint',
-        description => $group_hint,
-        %options,
-    );
+    if ($hint || $group_hint) {
+        my $description = $group_hint ? '<p>' . $group_hint . '</p>' : '';
+        $description .= $hint ? '<p>' . $hint . '</p>' : '';
+        if ($description) {
+            push @{ $service->attributes }, Open311::Endpoint::Service::Attribute->new(
+              description => $description,
+              %options,
+            );
+        };
+    };
 
     return $service;
 }

--- a/t/open311/endpoint/rutland_salesforce.t
+++ b/t/open311/endpoint/rutland_salesforce.t
@@ -989,24 +989,13 @@ subtest "check fetch service metadata" => sub {
             description => "Additional Information",
           },
           {
-            variable => 'false',
-            code => "hint",
-            datatype => "string",
-            required => 'false',
-            datatype_description => '',
-            order => 6,
-            description => "<span>This is the category HTML hint</span>",
-            automated => 'server_set',
-          },
-          {
-            variable => 'false',
-            code => "group_hint",
-            datatype => "string",
-            required => 'false',
-            datatype_description => '',
-            order => 7,
-            description => "<span>This is the group HTML hint</span>",
-            automated => 'server_set',
+           "variable" => "false",
+           "required" => "false",
+           "order" => 6,
+           "code" => "notice",
+           "description" => "<p><span>This is the group HTML hint</span></p><p><span>This is the category HTML hint</span></p>",
+           "datatype" => "string",
+           "datatype_description" => "",
           }
         ]
     }, 'correct json returned';

--- a/t/open311/endpoint/rutland_salesforce.t
+++ b/t/open311/endpoint/rutland_salesforce.t
@@ -30,6 +30,25 @@ has is_success => (
     default => 1
 );
 
+package Integrations::SalesForce::Rutland::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Integrations::SalesForce::Rutland';
+sub _build_config_file { path(__FILE__)->sibling("rutland_salesforce.yml")->stringify }
+
+package Open311::Endpoint::Integration::UK::Rutland::SalesForce::Dummy;
+use Path::Tiny;
+use Moo;
+extends 'Open311::Endpoint::Integration::UK::Rutland::SalesForce';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{jurisdiction_id} = 'rutland_salesforce';
+    $args{config_file} = path(__FILE__)->sibling("rutland_salesforce.yml")->stringify;
+    return $class->$orig(%args);
+};
+has integration_class => (is => 'ro', default => 'Integrations::SalesForce::Rutland::Dummy');
+
+
 package main;
 
 use strict; use warnings;
@@ -44,12 +63,13 @@ use Test::MockTime ':all';
 use Open311::Endpoint;
 use Data::Dumper;
 use JSON::MaybeXS;
+use Path::Tiny;
 
 BEGIN { $ENV{TEST_MODE} = 1; }
-use Open311::Endpoint::Integration::UK::Rutland::SalesForce;
-use Integrations::SalesForce::Rutland;
+use Open311::Endpoint::Integration::UK::Rutland::SalesForce::Dummy;
+use Integrations::SalesForce::Rutland::Dummy;
 
-my $endpoint = Open311::Endpoint::Integration::UK::Rutland::SalesForce->new;
+my $endpoint = Open311::Endpoint::Integration::UK::Rutland::SalesForce::Dummy->new;
 
 my %responses = (
     'new_report' => '[{ "Id": "12345" }]',
@@ -884,15 +904,6 @@ subtest "check fetch service description" => sub {
         type => "realtime",
         keywords => "",
         group => "Street Furniture"
-    },
-    {
-        metadata => "true",
-        description => "Phasing/timing issues",
-        group => "Traffic Lights - Permanent",
-        service_code => "a012500000JJ0neAAD",
-        type => "realtime",
-        service_name => "Phasing/timing issues",
-        keywords => ""
     } ], 'correct json returned'
         or diag $res->content;
 };

--- a/t/open311/endpoint/rutland_salesforce.yml
+++ b/t/open311/endpoint/rutland_salesforce.yml
@@ -1,0 +1,3 @@
+whitelist:
+  Fly Tipping: 1
+


### PR DESCRIPTION
Adds category whitelisting for Rutland Salesforce to filter out duplicates when Confirm integration goes live

Remove 'hints' feature so that extra data is now passed to be a notice in FMS.

https://github.com/mysociety/societyworks/issues/5400