### PR TITLE
[Open311] Enable multiple media_url items in service request updates

### DIFF
--- a/perllib/Open311/Endpoint.pm
+++ b/perllib/Open311/Endpoint.pm
@@ -824,8 +824,13 @@ sub format_service_requests {
                     ),
                     (
                         map {
-                            my $value = $request->$_->[0];
-                            $_ => $value || '';
+                            my $value;
+                            if (scalar @{ $request->$_ } <= 1) {
+                                $value = $request->$_->[0] || '';
+                            } else {
+                                $value = $request->@{$_};
+                            }
+                            $_ => $value;
                         }
                         qw/
                             media_url

--- a/perllib/Open311/Endpoint/Role/mySociety.pm
+++ b/perllib/Open311/Endpoint/Role/mySociety.pm
@@ -286,8 +286,13 @@ sub format_updates {
                     ),
                     (
                         map {
-                            my $value = $update->$_->[0];
-                            $_ => $value || '';
+                            my $value;
+                            if (scalar @{ $update->$_ } <= 1) {
+                                $value = $update->$_->[0] || '';
+                            } else {
+                                $value = $update->@{$_};
+                            }
+                            $_ => $value;
                         }
                         qw/
                             media_url
@@ -375,7 +380,7 @@ sub learn_additional_types {
                 status => '/open311/status_extended',
                 updated_datetime => '/open311/datetime',
                 description => '//str',
-                media_url => '//str',
+                media_url => { type => '//any', of => [ { type => '//str' }, { type => '//arr', contents => '//str' } ] },
             },
             optional => {
                 external_status_code => '//str',
@@ -403,7 +408,7 @@ sub learn_additional_types {
                 zipcode => '//str',
                 lat => '//num',
                 long => '//num',
-                media_url => '//str',
+                media_url => { type => '//any', of => [ { type => '//str' }, { type => '//arr', contents => '//str' } ] },
             },
             optional => {
                 title => '//str',

--- a/t/open311/endpoint/confirm_photos.t
+++ b/t/open311/endpoint/confirm_photos.t
@@ -96,7 +96,11 @@ subtest "fetching of job photos for enquiry update" => sub {
         GET => '/servicerequestupdates.xml?start_date=2025-01-01T00:00:00Z&end_date=2025-01-01T01:00:00Z',
     );
     ok $res->is_success, 'valid request' or diag $res->content;
-    contains_string $res->content, '<media_url>http://example.com/photos?jurisdiction_id=confirm_dummy_photos&amp;job=432&amp;photo=1</media_url>';
+    contains_string $res->content,
+    '<media_url>
+      <media_url>http://example.com/photos?jurisdiction_id=confirm_dummy_photos&amp;job=432&amp;photo=1</media_url>
+      <media_url>http://example.com/photos?jurisdiction_id=confirm_dummy_photos&amp;job=432&amp;photo=2</media_url>
+    </media_url>';
 
     $lwp->mock(request => \&empty_json);
     $integration->mock(perform_request => \&empty_json);


### PR DESCRIPTION
Continues passing as string if one or empty array presented, otherwise will pass as array.

For Rutland Completion Before/After photos, but system wide change

https://github.com/mysociety/societyworks/issues/5449