### PR TITLE
[Bartec] Reduce ServiceRequests_History_Get API calls

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Bartec.pm
+++ b/perllib/Open311/Endpoint/Integration/Bartec.pm
@@ -102,7 +102,7 @@ sub _get_service_name {
     my ($self, $service) = @_;
 
     $service->{Description} =~ s/(.)(.*)/\U$1\L$2/;
-    (my $class = $service->{ServiceClass}->{Description}) =~ s/(.)(.*)/\U$1\L$2/;
+    (my $class = $service->{ServiceClass}->{Name}) =~ s/(.)(.*)/\U$1\L$2/;
     my $service_name = $service->{Description};
 
     # service type names are not unique in bartec so need to distinguish
@@ -130,8 +130,8 @@ sub _allowed_service {
 
     return 1 if $self->allowed_services->{uc $service->{Description}} ||
                 (
-                    $self->service_map->{uc $service->{ServiceClass}->{Description}} &&
-                    $self->service_map->{uc $service->{ServiceClass}->{Description}}->{uc $service->{Description}}
+                    $self->service_map->{uc $service->{ServiceClass}->{Name}} &&
+                    $self->service_map->{uc $service->{ServiceClass}->{Name}}->{uc $service->{Description}}
                 );
 
     return 0;
@@ -439,6 +439,18 @@ sub get_service_request_updates {
     my @updates;
     my $updates = $self->get_integration->_coerce_to_array( $response, 'ServiceRequest_Updates' );
     for my $update ( @$updates ) {
+        my $ref = $update->{JobReference} // ''; # JobReference is the external (to Bartec) ID, i.e. FMS report ID
+        next unless $ref =~ /^\d{7,}$/; # skip ServiceRequest if its job ref doesn't look like an FMS ID
+
+        # Skip updates for ServiceRequests whose services we're not responsible for
+        my $service = {
+            Description => $update->{ServiceType},
+            ServiceClass => {
+                Name => $update->{ServiceClass},
+            }
+        };
+        next unless $self->_allowed_service($service);
+
         my $history = $self->get_integration->ServiceRequests_History_Get( $update->{ServiceRequestID}, $history_start_date );
 
         next unless $history->{ServiceRequest_History};

--- a/t/open311/endpoint/bartec.t
+++ b/t/open311/endpoint/bartec.t
@@ -1247,6 +1247,7 @@ subtest 'get uprn for usrn with one result' => sub {
 };
 
 subtest 'fetch updates' => sub {
+    %sent = ();
     my $res = $endpoint->run_test_request(
         GET => '/servicerequestupdates.json?jurisdiction_id=bartec&start_date=2020-06-19T10:00:00Z&end_date=2020-06-19T12:00:00Z'
     );
@@ -1261,46 +1262,43 @@ subtest 'fetch updates' => sub {
         LastUpdated => '2020-06-19T10:00:00Z',
     }, 'correct fetch updates request sent';
 
+    # Only the entry with an allowed service (LEAF REMOVAL) AND a valid 7+ digit
+    # JobReference (1234567) should trigger a history call. The WASTE/GW BIN
+    # OPERATION entry (wrong service), the WASTE/GW NEW SUBSCRIPTION entry
+    # (wrong service, short JobReference), and the LEAF REMOVAL entry with short
+    # JobReference (843) must all be skipped.
     is_deeply $sent_history->body->{ServiceRequests_History_Get}, {
         token => 'ABC=',
         ServiceRequestID => '51340',
         Date => '1753-01-01T00:00:00Z',
-    }, 'correct fetch history request sent';
+    }, 'history only fetched for allowed service with valid JobReference';
 
     is_deeply decode_json($res->content), [
         {
-            update_id =>228025,
-            service_request_id =>'SR00051627',
-            status =>'open',
-            updated_datetime => '2020-06-17T09:47:26+01:00',
-            description =>'',
-            media_url =>'',
-        },
-        {
-            update_id =>228026,
-            service_request_id =>'SR00051628',
-            status =>'fixed',
-            updated_datetime => '2020-06-17T09:48:26+01:00',
-            description =>'',
-            media_url =>'',
-        },
-        {
-            update_id =>228027,
-            service_request_id =>'SR00051627',
-            status =>'open',
-            updated_datetime => '2020-06-17T09:55:36+01:00',
-            description =>'',
-            media_url =>'',
-        },
-        {
-            update_id =>228028,
-            service_request_id =>'SR00051624',
-            status =>'closed',
+            update_id => 228028,
+            service_request_id => 'SR00051624',
+            status => 'closed',
             updated_datetime => '2020-06-17T09:59:26+01:00',
-            description =>'',
-            media_url =>'',
-        }
-    ], 'correct return';
+            description => '',
+            media_url => '',
+        },
+    ], 'only updates for allowed services with valid JobReference returned';
+};
+
+subtest 'fetch updates - all entries filtered' => sub {
+    %sent = ();
+    my $res = $endpoint->run_test_request(
+        GET => '/servicerequestupdates.json?jurisdiction_id=bartec&start_date=2020-06-23T10:00:00Z&end_date=2020-06-23T12:00:00Z'
+    );
+
+    ok $res->is_success, 'valid request'
+        or diag $res->content;
+
+    is $sent{ServiceRequests_History_Get}, undef,
+        'no history calls when all updates are filtered out';
+
+    is_deeply decode_json($res->content), [],
+        'empty result when all updates filtered';
 };
 
 subtest 'fetch_requests' => sub {

--- a/t/open311/endpoint/xml/bartec/servicerequests_updates_get_20200619.xml
+++ b/t/open311/endpoint/xml/bartec/servicerequests_updates_get_20200619.xml
@@ -1,9 +1,9 @@
     <ServiceRequests_Updates_GetResponse xmlns="http://bartec-systems.com/">
-      <ServiceRequests_Updates_GetResult xmlns="http://www.bartec-systems.com/ServiceRequests_Updates_Get.xsd" RecordCount="11">
+      <ServiceRequests_Updates_GetResult xmlns="http://www.bartec-systems.com/ServiceRequests_Updates_Get.xsd" RecordCount="4">
         <ServiceRequest_Updates RecordCount="0">
           <ServiceRequestID>51389</ServiceRequestID>
           <ServiceCode>SR00051688</ServiceCode>
-          <JobReference/>
+          <JobReference>9012341</JobReference>
           <ServiceCategory>General</ServiceCategory>
           <ServiceClass>WASTE</ServiceClass>
           <ServiceType>GW BIN OPERATION</ServiceType>
@@ -21,12 +21,22 @@
           <DateChanged>2020-06-19T15:04:56.317</DateChanged>
         </ServiceRequest_Updates>
         <ServiceRequest_Updates RecordCount="0">
+          <ServiceRequestID>51341</ServiceRequestID>
+          <ServiceCode>SR00051689</ServiceCode>
+          <JobReference>843</JobReference>
+          <ServiceCategory>General</ServiceCategory>
+          <ServiceClass>STREET CLEANSING</ServiceClass>
+          <ServiceType>LEAF REMOVAL</ServiceType>
+          <DateAdded>0001-01-01T00:00:00</DateAdded>
+          <DateChanged>2020-06-19T15:04:56.317</DateChanged>
+        </ServiceRequest_Updates>
+        <ServiceRequest_Updates RecordCount="0">
           <ServiceRequestID>51340</ServiceRequestID>
           <ServiceCode>SR00051624</ServiceCode>
-          <JobReference/>
+          <JobReference>1234567</JobReference>
           <ServiceCategory>General</ServiceCategory>
-          <ServiceClass>WASTE</ServiceClass>
-          <ServiceType>GW BIN OPERATION</ServiceType>
+          <ServiceClass>STREET CLEANSING</ServiceClass>
+          <ServiceType>LEAF REMOVAL</ServiceType>
           <DateAdded>0001-01-01T00:00:00</DateAdded>
           <DateChanged>2020-06-19T15:04:56.007</DateChanged>
         </ServiceRequest_Updates>

--- a/t/open311/endpoint/xml/bartec/servicerequests_updates_get_20200623.xml
+++ b/t/open311/endpoint/xml/bartec/servicerequests_updates_get_20200623.xml
@@ -1,0 +1,28 @@
+    <ServiceRequests_Updates_GetResponse xmlns="http://bartec-systems.com/">
+      <ServiceRequests_Updates_GetResult xmlns="http://www.bartec-systems.com/ServiceRequests_Updates_Get.xsd" RecordCount="2">
+        <ServiceRequest_Updates RecordCount="0">
+          <ServiceRequestID>51400</ServiceRequestID>
+          <ServiceCode>SR00051700</ServiceCode>
+          <JobReference/>
+          <ServiceCategory>General</ServiceCategory>
+          <ServiceClass>WASTE</ServiceClass>
+          <ServiceType>GW BIN OPERATION</ServiceType>
+          <DateAdded>0001-01-01T00:00:00</DateAdded>
+          <DateChanged>2020-06-23T10:01:00.000</DateChanged>
+        </ServiceRequest_Updates>
+        <ServiceRequest_Updates RecordCount="0">
+          <ServiceRequestID>51401</ServiceRequestID>
+          <ServiceCode>SR00051701</ServiceCode>
+          <JobReference>JOB1234567</JobReference>
+          <ServiceCategory>General</ServiceCategory>
+          <ServiceClass>STREET CLEANSING</ServiceClass>
+          <ServiceType>LEAF REMOVAL</ServiceType>
+          <DateAdded>0001-01-01T00:00:00</DateAdded>
+          <DateChanged>2020-06-23T10:02:00.000</DateChanged>
+        </ServiceRequest_Updates>
+        <Errors>
+          <Result xmlns="http://www.bartec-systems.com">0</Result>
+          <Message xmlns="http://www.bartec-systems.com"/>
+        </Errors>
+      </ServiceRequests_Updates_GetResult>
+    </ServiceRequests_Updates_GetResponse>


### PR DESCRIPTION
We were making API calls to fetch history for service requests from other CRMs and for service request types that we don't handle.

For FD-6864