### PR TITLE
[Central Beds] Do not pull in updates for Jadu

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/CentralBedfordshire/Jadu.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/CentralBedfordshire/Jadu.pm
@@ -545,6 +545,12 @@ Reads updates from C<update_storage_file>.
 
 sub get_service_request_updates {
     my ($self, $args) = @_;
+
+    # Do not pull in updates as we mark reports in Jadu category (i.e.
+    # Fly Tipping) as closed automatically; pulling in updates reopens them
+    # with 'investigating' status
+    return () if $self->endpoint_config->{ignore_updates_from_jadu};
+
     my $w3c = DateTime::Format::W3CDTF->new;
     my $start_time = $w3c->parse_datetime($args->{start_date})->epoch;
     my $end_time = $w3c->parse_datetime($args->{end_date})->epoch;


### PR DESCRIPTION
We do not want to pull in updates as we mark reports in Jadu category (i.e. Fly Tipping) as closed automatically; pulling in updates reopens them with the 'investigating' status.