### PR TITLE
[Lincs] Defaults for fetched reports when multiple cats at our end

### DIFF
--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -1357,6 +1357,9 @@ sub _parse_enquiry {
 
     my %args = (
         service => $service,
+        extras => {
+            group => @{$service->groups} ? $service->groups->[0] : $service->group,
+        },
         service_request_id => $enquiry->{EnquiryNumber},
         description => $enquiry->{EnquiryDescription},
         address => $enquiry->{EnquiryLocation} || '',
@@ -1366,6 +1369,9 @@ sub _parse_enquiry {
         latlong => [ $enquiry->{EnquiryY}, $enquiry->{EnquiryX} ],
         status => $status,
     );
+    if ($service->service_code !~ /^$code/) { # If it's wrapped
+        $args{extras}{original_service_code} = $code;
+    }
 
     if ( $self->fetch_reports_private || $private_services->{$code} ) {
         $args{non_public} = 1;

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -85,6 +85,18 @@ has handle_jobs => (
     }
 );
 
+=head2 sync_category
+
+Whether when fetching updates we include the Confirm category/group/service code
+in the update to potentially update FixMyStreet. Requires graphql to be in use.
+
+=cut
+
+has sync_category => (
+    is => 'ro',
+    default => 0,
+);
+
 =head2 job_service_whitelist
 
 Controls the mapping of Confirm job service/subject codes to Open311 services
@@ -694,7 +706,7 @@ GRAPHQL
             my $extras = {};
             my $service_code = $status_log->{centralEnquiry}->{serviceCode} . "_" . $status_log->{centralEnquiry}->{subjectCode};
             my $service = $services{$service_code} || $self->_find_wrapping_service($service_code, \%services);
-            if ( $service ) {
+            if ( $service && $self->sync_category) {
                 $extras = {
                     category => $service->service_name,
                     group => @{$service->groups} ? $service->groups->[0] : $service->group,

--- a/perllib/Open311/Endpoint/Integration/Confirm.pm
+++ b/perllib/Open311/Endpoint/Integration/Confirm.pm
@@ -1386,6 +1386,10 @@ sub _parse_enquiry {
         }
     }
 
+    if ($self->can('munge_new_request')) {
+        $self->munge_new_request(\%args, $services);
+    }
+
     return $self->new_request( %args );
 }
 

--- a/perllib/Open311/Endpoint/Integration/UK/Lincolnshire.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Lincolnshire.pm
@@ -31,4 +31,33 @@ sub photo_filter {
     return $filename_ok && $notes_ok;
 }
 
+# We have a number of Confirm service/subject codes that have more than one
+# entry in FMS. We have a manual list of which FMS category to use in these
+# cases. This depends on whether it's a category in more than one group, or
+# one that is both wrapped and not, or one that is wrapped in two different
+# categories, or one that's wrapped twice in the same category, or one that
+# is two different categories...
+
+sub munge_new_request {
+    my ($self, $args, $services) = @_;
+
+    my $sc = $args->{service}->service_code;
+    my $osc = $args->{extras}->{original_service_code} || '';
+    if ($sc eq 'HMOB_MO06' || $sc eq 'HMOB_MO05') {
+        $args->{extras}->{group} = 'Roads and cycleways';
+    } elsif ($sc eq 'SD_HSF9_2') {
+        $args->{service} = $services->{TRIP_HAZARD};
+        $args->{extras}->{original_service_code} = 'SD_HSF9';
+        $args->{extras}->{group} = 'Pavement and verge';
+    } elsif ($sc eq 'HMVG_MV05_2') {
+        $args->{service} = $services->{HMVG_MV05_1};
+    } elsif ($osc eq 'PRWD_RW41') {
+        $args->{service} = $services->{PROW_TREES}; # in case it's PROW_OBS
+    } elsif ($osc eq 'HMOB_MO02') {
+        $args->{extras}->{original_service_code} = 'HMOB_MO02_2';
+    } elsif ($osc eq 'HMOB_MO10') {
+        $args->{extras}->{original_service_code} = 'HMOB_MO10_1';
+    }
+}
+
 1;

--- a/t/open311/endpoint/confirm.t
+++ b/t/open311/endpoint/confirm.t
@@ -1414,7 +1414,9 @@ my $expected = <<XML;
     <address></address>
     <address_id></address_id>
     <description>this is a report from confirm</description>
-    <extras></extras>
+    <extras>
+      <group>Flooding</group>
+    </extras>
     <lat>100</lat>
     <long>100</long>
     <media_url></media_url>
@@ -1452,7 +1454,9 @@ my $expected = <<XML;
     <address></address>
     <address_id></address_id>
     <description>this is a report from confirm</description>
-    <extras></extras>
+    <extras>
+      <group>Flooding &amp; Drainage</group>
+    </extras>
     <lat>100</lat>
     <long>100</long>
     <media_url></media_url>
@@ -1490,7 +1494,9 @@ my $expected = <<XML;
     <address></address>
     <address_id></address_id>
     <description>this is a report from confirm</description>
-    <extras></extras>
+    <extras>
+      <group>Flooding &amp; Drainage</group>
+    </extras>
     <lat>100</lat>
     <long>100</long>
     <media_url></media_url>
@@ -1552,7 +1558,9 @@ my $expected = <<XML;
     <address></address>
     <address_id></address_id>
     <description>this is a report from confirm</description>
-    <extras></extras>
+    <extras>
+      <group>Flooding &amp; Drainage</group>
+    </extras>
     <lat>100</lat>
     <long>100</long>
     <media_url></media_url>
@@ -1600,7 +1608,10 @@ my $expected = <<XML;
     <address></address>
     <address_id></address_id>
     <description>this is a report from confirm</description>
-    <extras></extras>
+    <extras>
+      <group>Road/Footpath Problems</group>
+      <original_service_code>ABC_DEF</original_service_code>
+    </extras>
     <lat>100</lat>
     <long>100</long>
     <media_url></media_url>
@@ -1775,7 +1786,7 @@ subtest 'GET jobs alongside enquiries' => sub {
                 {   address            => undef,
                     address_id         => undef,
                     description        => 'this is a report from confirm',
-                    extras             => undef,
+                    extras             => { group => 'Flooding & Drainage' },
                     lat                => '100',
                     long               => '100',
                     media_url          => undef,
@@ -1987,7 +1998,7 @@ subtest 'GET reports - external system number filtering' => sub {
                 {   address            => undef,
                     address_id         => undef,
                     description        => 'this is a report from confirm',
-                    extras             => undef,
+                    extras             => { group => 'Flooding & Drainage'},
                     lat                => '100',
                     long               => '100',
                     media_url          => undef,
@@ -2002,7 +2013,7 @@ subtest 'GET reports - external system number filtering' => sub {
                 {   address            => undef,
                     address_id         => undef,
                     description        => 'this is a report from another system',
-                    extras             => undef,
+                    extras             => { group => 'Flooding & Drainage'},
                     lat                => '200',
                     long               => '200',
                     media_url          => undef,

--- a/t/open311/endpoint/confirm_jobs.yml
+++ b/t/open311/endpoint/confirm_jobs.yml
@@ -4,6 +4,7 @@ username: "username"
 password: "pw"
 tenant_id: "123"
 graphql_key: "key"
+sync_category: 1
 server_timezone: Europe/London
 default_site_code: 999999
 service_whitelist:

--- a/t/open311/endpoint/confirm_wrapped.t
+++ b/t/open311/endpoint/confirm_wrapped.t
@@ -8,6 +8,7 @@ around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
     $args{jurisdiction_id} = 'confirm_wrapped';
     $args{config_data} = '
+sync_category: 1
 service_whitelist:
    Everything:
      HM_PHS: Small pothole

--- a/t/open311/endpoint/lincolnshire.t
+++ b/t/open311/endpoint/lincolnshire.t
@@ -42,6 +42,17 @@ around BUILDARGS => sub {
 };
 has integration_class => (is => 'ro', default => 'Integrations::Confirm::DummyGraphQL');
 
+package Open311::Endpoint::Integration::UK::Dummy::Lincolnshire;
+use Path::Tiny;
+use Moo;
+extends 'Open311::Endpoint::Integration::UK::Lincolnshire';
+around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+    $args{config_file} = path(__FILE__)->sibling("lincolnshire.yml")->stringify;
+    return $class->$orig(%args);
+};
+has integration_class => (is => 'ro', default => 'Integrations::Confirm::Dummy');
+
 package main;
 
 my $open311 = Test::MockModule->new('Integrations::Confirm');
@@ -226,6 +237,99 @@ subtest "no photos returned when all are 'before'" => sub {
     ok $res->is_success, 'valid request' or diag $res->content;
     contains_string $res->content, '<media_url></media_url>', 'no photos returned when all are before';
     $graphql_integration->unmock('perform_request_graphql');
+};
+
+subtest 'cope with defaults of fetched enquiries' => sub {
+    $open311->mock(perform_request => sub {
+        my ($self, $op) = @_; # Don't care about subsequent ops
+        $op = $$op;
+        if ($op->name && $op->name eq 'GetEnquiryLookups') {
+            return {
+                OperationResponse => { GetEnquiryLookupsResponse => { TypeOfService => [
+                    { ServiceCode => 'HMOB', ServiceName => 'HMOB', EnquirySubject => [
+                        { SubjectCode => "MO02" },
+                        { SubjectCode => "MO05" },
+                        { SubjectCode => "MO06" },
+                        { SubjectCode => "MO10" },
+                    ] },
+                    { ServiceCode => 'SD', ServiceName => 'SD', EnquirySubject => [
+                        { SubjectCode => "HSF9" },
+                    ] },
+                    { ServiceCode => 'PRWD', ServiceName => 'PRWD', EnquirySubject => [
+                        { SubjectCode => "RW41" },
+                    ] },
+                    { ServiceCode => 'HMVG', ServiceName => 'HMVG', EnquirySubject => [
+                        { SubjectCode => "MV05" },
+                    ] },
+                ] } }
+            };
+        } elsif ( $op->name && $op->name eq 'GetEnquiry' ) {
+            return { OperationResponse => [
+              { GetEnquiryResponse => { Enquiry => {
+                ServiceCode => 'HMOB', SubjectCode => 'MO02', EnquiryStatusCode => 'INP', EnquiryDescription => 'this is a report from confirm', EnquiryNumber => '2003', EnquiryX => '100', EnquiryY => '100', EnquiryLogTime => '2018-04-17T12:34:56Z', LoggedTime => '2018-04-17T12:34:56Z'
+              } } },
+              { GetEnquiryResponse => { Enquiry => {
+                ServiceCode => 'HMOB', SubjectCode => 'MO05', EnquiryStatusCode => 'INP', EnquiryDescription => 'this is a report from confirm', EnquiryNumber => '2003', EnquiryX => '100', EnquiryY => '100', EnquiryLogTime => '2018-04-17T12:34:56Z', LoggedTime => '2018-04-17T12:34:56Z'
+              } } },
+              { GetEnquiryResponse => { Enquiry => {
+                ServiceCode => 'HMOB', SubjectCode => 'MO06', EnquiryStatusCode => 'INP', EnquiryDescription => 'this is a report from confirm', EnquiryNumber => '2003', EnquiryX => '100', EnquiryY => '100', EnquiryLogTime => '2018-04-17T12:34:56Z', LoggedTime => '2018-04-17T12:34:56Z'
+              } } },
+              { GetEnquiryResponse => { Enquiry => {
+                ServiceCode => 'HMOB', SubjectCode => 'MO10', EnquiryStatusCode => 'INP', EnquiryDescription => 'this is a report from confirm', EnquiryNumber => '2003', EnquiryX => '100', EnquiryY => '100', EnquiryLogTime => '2018-04-17T12:34:56Z', LoggedTime => '2018-04-17T12:34:56Z'
+              } } },
+              { GetEnquiryResponse => { Enquiry => {
+                ServiceCode => 'HMVG', SubjectCode => 'MV05', EnquiryStatusCode => 'INP', EnquiryDescription => 'this is a report from confirm', EnquiryNumber => '2003', EnquiryX => '100', EnquiryY => '100', EnquiryLogTime => '2018-04-17T12:34:56Z', LoggedTime => '2018-04-17T12:34:56Z'
+              } } },
+              { GetEnquiryResponse => { Enquiry => {
+                ServiceCode => 'PRWD', SubjectCode => 'RW41', EnquiryStatusCode => 'INP', EnquiryDescription => 'this is a report from confirm', EnquiryNumber => '2003', EnquiryX => '100', EnquiryY => '100', EnquiryLogTime => '2018-04-17T12:34:56Z', LoggedTime => '2018-04-17T12:34:56Z'
+              } } },
+              { GetEnquiryResponse => { Enquiry => {
+                ServiceCode => 'SD', SubjectCode => 'HSF9', EnquiryStatusCode => 'INP', EnquiryDescription => 'this is a report from confirm', EnquiryNumber => '2003', EnquiryX => '100', EnquiryY => '100', EnquiryLogTime => '2018-04-17T12:34:56Z', LoggedTime => '2018-04-17T12:34:56Z'
+              } } },
+            ] };
+        }
+        $op = $op->value;
+        if ($op->name eq 'GetEnquiryStatusChanges') {
+            my %req = map { $_->name => $_->value } ${$op->value}->value;
+            return { OperationResponse => { GetEnquiryStatusChangesResponse => { UpdatedEnquiry => [
+                { EnquiryNumber => 2003, EnquiryStatusLog => [ { EnquiryLogNumber => 5, LogEffectiveTime => '2022-10-23T12:00:00Z', LoggedTime => '2022-10-23T12:00:00Z', EnquiryStatusCode => 'INP' } ] },
+                { EnquiryNumber => 2020, EnquiryStatusLog => [ { EnquiryLogNumber => 5, LogEffectiveTime => '2022-10-23T12:00:00Z', LoggedTime => '2022-10-23T12:00:00Z', EnquiryStatusCode => 'FIX' } ] },
+            ] } } };
+        }
+        return {};
+    });
+
+    my $endpoint = Open311::Endpoint::Integration::UK::Dummy::Lincolnshire->new;
+    my $lwp = Test::MockModule->new('LWP::UserAgent');
+    $lwp->mock(request => sub {
+        my ($ua, $req) = @_;
+        return HTTP::Response->new(200, 'OK', [], '{"access_token":"123","expires_in":3600}') if $req->uri =~ /oauth\/token/;
+        return HTTP::Response->new(200, 'OK', [], '{"customers":[{"contact":{"fullName":"John Smith", "email":"john@example.org"}}]}') if $req->uri =~ /enquiries\/2003/;
+    });
+    my $res = $endpoint->run_test_request(
+        GET => '/requests.xml?jurisdiction_id=lincolnshire_confirm&start_date=2022-10-23T00:00:00Z&end_date=2022-10-24T00:00:00Z',
+    );
+    ok $res->is_success, 'valid request' or diag $res->content;
+
+    my @reports = split /<request>/, $res->content;
+
+    my @out = (
+        { group => 'Pavement and verge', service_code => 'TRIP_HAZARD', osc => 'SD_HSF9' },
+        { group => 'PROW', service_code => 'PROW_TREES', osc => 'PRWD_RW41' },
+        { group => 'Trees', service_code => 'HMVG_MV05_1' },
+        { group => 'Trees', service_code => 'TREE_HANGING', osc => 'HMOB_MO10_1' },
+        { group => "Roads and cycleways", service_code => 'HMOB_MO06' },
+        { group => "Roads and cycleways", service_code => 'HMOB_MO05' },
+        { group => 'Trees', service_code => 'TREES_FALLEN', osc => 'HMOB_MO02_2' },
+    );
+
+    foreach (@out) {
+        my $r = pop @reports;
+        contains_string $r, "<group>$_->{group}</group>";
+        contains_string $r, "<service_code>$_->{service_code}</service_code>";
+        contains_string $r, "<original_service_code>$_->{osc}</original_service_code>"
+            if $_->{osc};
+    }
 };
 
 done_testing;

--- a/t/open311/endpoint/lincolnshire.yml
+++ b/t/open311/endpoint/lincolnshire.yml
@@ -1,0 +1,64 @@
+endpoint_url: "http://confirm/endpoint"
+base_url: http://confirm/
+web_url: http://confirm/web/api
+username: "username"
+password: "pw"
+tenant_id: "123"
+server_timezone: Europe/London
+default_site_code: 999999
+service_whitelist:
+  All:
+    HMOB_MO06: Advert
+    HMOB_MO05: Obstruction (Road)
+    SD_HSF9: Trip hazard
+    SD_HSF9_2: Tree roots
+    PRWD_RW41: Hedge outgrowth
+    HMOB_MO02: On pavement
+    HMOB_MO02_2: On road
+    HMOB_MO10: On pavement
+    HMOB_MO10_1: On road
+    HMVG_MV05_1: Hedge in the way
+    HMVG_MV05_2: Tree blocking light
+
+reverse_status_mapping:
+  DUP: duplicate
+  INP: in_progress
+  FIX: fixed
+  FOR: for_triage
+
+wrapped_services:
+  HMOB_MO06:
+    passthrough: 1
+    group: ["Pavement", "Roads"]
+  HMOB_MO05:
+    passthrough: 1
+    group: ["Pavement", "Roads"]
+  SD_HSF9_2:
+    passthrough: 1
+    group: Trees
+  TRIP_HAZARD:
+    group: Pavement
+    name: Trip hazard
+    wraps: ["SD_HSF9"]
+  PROW_TREES:
+    group: PROW
+    name: Trees
+    wraps: ["PRWD_RW41"]
+  PROW_OBS:
+    group: PROW
+    name: Obstruction
+    wraps: ["PRWD_RW41"]
+  TREES_FALLEN:
+    group: Trees
+    name: Fallen tree
+    wraps: ["HMOB_MO02", "HMOB_MO02_2"]
+  TREE_HANGING:
+    group: Trees
+    name: Hanging tree
+    wraps: ["HMOB_MO10", "HMOB_MO10_1"]
+  HMVG_MV05_1:
+    passthrough: 1
+    group: Trees
+  HMVG_MV05_2:
+    passthrough: 1
+    group: Trees


### PR DESCRIPTION
And also pass through group/original service code in fetched requests, as we do with updates.
And add flag for syncing category.
For FD-6811
