### PR TITLE
[Dumfries] Setting 'responsibility' on the extras of an update

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/Dumfries.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/Dumfries.pm
@@ -266,21 +266,44 @@ sub _get_inspection_updates_design {
             if ($mapping && $mapping->{extra_attributes} && $mapping->{extra_attributes}{latest_inspection_time}) {
                 my $latest_inspection = $self->_find_latest_inspection($report);
                 if ($latest_inspection) {
-                    my $inspection_attrs = $self->alloy->attributes_to_hash($latest_inspection);
-                    my $completion_time = $inspection_attrs->{attributes_tasksCompletionTime};
-
-                    if ($completion_time) {
-                        $completion_time = $completion_time->[0] if ref $completion_time eq 'ARRAY';
-                        $update->{extras}{latest_inspection_time} = $completion_time;
-                    } else {
-                        $update->{extras}{latest_inspection_time} = 'NOT COMPLETE';
-                    }
+                    $self->_set_extras_on_fetched_updates($latest_inspection, $update);
                 }
             }
         }
     }
 
     return (\@updates, $items_by_id);
+}
+
+=head2 _set_extras_on_fetched_updates
+
+Use the latest inspection to add 'extras' to an update so that we can
+carry forward extra information to be shown on FMS
+
+=cut
+
+
+sub _set_extras_on_fetched_updates {
+    my ($self, $latest_inspection, $update) = @_;
+
+    my $inspection_attrs = $self->alloy->attributes_to_hash($latest_inspection);
+    my $completion_time = $inspection_attrs->{attributes_tasksCompletionTime};
+
+    if ($completion_time) {
+        $completion_time = $completion_time->[0] if ref $completion_time eq 'ARRAY';
+        $update->{extras}{latest_inspection_time} = $completion_time;
+    } else {
+        $update->{extras}{latest_inspection_time} = 'NOT COMPLETE';
+    }
+
+    my $mapping = $self->config->{other_responsibility_mapping};
+    if (
+        $mapping && (my $responsibility = $inspection_attrs->{ $mapping->{'highway'} })
+       )
+    {
+        $responsibility = $responsibility->[0] if ref $responsibility eq 'ARRAY';
+        $update->{extras}{responsibility} = $mapping->{'fields'}{$responsibility} || '';
+    };
 }
 
 =head2 get_photo

--- a/t/open311/endpoint/dumfries_alloy.t
+++ b/t/open311/endpoint/dumfries_alloy.t
@@ -30,6 +30,7 @@ use JSON::MaybeXS;
 use Path::Tiny;
 use YAML::XS qw(LoadFile);
 use Data::Dumper;
+use DateTime;
 
 BEGIN { $ENV{TEST_MODE} = 1; }
 
@@ -432,6 +433,16 @@ subtest 'priority pulled through' => sub {
       "description" => "",
       "service_request_id" => "63ee34826965f30390f01cda"
     }, 'Inspection update has correct data with priority';
+};
+
+subtest 'extras set on updates' => sub {
+    my $dumfries = Open311::Endpoint::Integration::UK::Dummy->new;
+    my $update = Open311::Endpoint::Service::Request::Update::mySociety->new('service_request_id' => '63ee34826965f30390f01cda', 'external_status_code' => '1212aad:1234ade:987ffa', 'description' => '', 'updated_datetime' =>  DateTime->today(), 'update_id' => 'test_id', 'status' => 'not_councils_responsibility');
+    my $latest_report = { 'attributes' =>  [ { "attributeCode" => "attributes_hWY3rdPartyResponsibility", "value" => [ "66e81123d77d63bb1e210d26" ] } ] };
+
+    $dumfries->_set_extras_on_fetched_updates($latest_report, $update);
+    is $update->extras->{responsibility}, 'Scottish Water', '3rd party added to responsibility';
+    is $update->extras->{latest_inspection_time}, 'NOT COMPLETE', 'latest_inspection_time set';
 };
 
 subtest 'defect updates include priority from extra_attributes' => sub {

--- a/t/open311/endpoint/dumfries_alloy.yml
+++ b/t/open311/endpoint/dumfries_alloy.yml
@@ -55,6 +55,13 @@ inspection_attribute_mapping:
   extra_attributes:
     priority: root.attributes_serviceEnquiryHWYPriority_652e86d3737fc1d2c84c720b.attributes_itemsTitle
 
+# Mapping of Alloy 3rd party assignees
+other_responsibility_mapping:
+  highway: attributes_hWY3rdPartyResponsibility
+  fields:
+    66e81123d77d63bb1e210d26: 'Scottish Water'
+    66e8138277068653dfdaac90: 'Other'
+
 # Mapping from incoming Open311 update parameters to inspection attributes
 update_to_inspection_attribute_mapping:
   updated_datetime: attributes_tasksRaisedTime


### PR DESCRIPTION
If there is a responsibility attribute, set it on the extra hash of an update so it can be passed through to FMS for use in templates.

Discussion on ticket about implementing this:
https://github.com/mysociety/societyworks/issues/5472