### PR TITLE
[Dumfries] Add Inspector notes to report with update

### DIFF
--- a/perllib/Open311/Endpoint/Integration/AlloyV2.pm
+++ b/perllib/Open311/Endpoint/Integration/AlloyV2.pm
@@ -832,12 +832,11 @@ sub _get_inspection_updates_design {
             };
 
             $args{extras} = { %{$args{extras}}, %$assigned_to_user } if $assigned_to_user;
-
-            if ( my $extra_details_code = $mapping->{extra_details} ) {
-                $args{extras}{detailed_information}
-                    = $attributes->{$extra_details_code} // '';
-            }
         }
+
+        $self->_add_extra_details(
+            $mapping->{extra_details}, $attributes, $args{extras}
+        ) if $mapping->{extra_details};
 
         $self->_apply_extra_attributes($mapping->{extra_attributes}, $attributes, $args{extras});
 
@@ -846,6 +845,36 @@ sub _get_inspection_updates_design {
     }
 
     return (\@updates, \%items_by_id);
+}
+
+=head2 _add_extra_details
+
+Adds a 'detailed_information' key to the 'extra' hash of an update which
+will be passed to FMS for the value to be added to the
+detailed_information on the report for staff only visiblility
+
+=cut
+
+sub _add_extra_details {
+    my ($self, $extra_details_config, $attributes, $extras) = @_;
+
+    my @fields;
+    if ( ref $extra_details_config eq 'HASH' ) {
+        $extras->{detailed_information} = '';
+
+        for ( sort keys %$extra_details_config ) {
+            $extras->{detailed_information}
+                .= $extra_details_config->{$_}
+                    . ":\n"
+                    . $attributes->{$_}
+                    . "\n\n"
+                if $attributes->{$_};
+        }
+
+    } else {
+        $extras->{detailed_information} = $attributes->{$extra_details_config}
+            // '';
+    }
 }
 
 sub _skip_inspection_update { }
@@ -976,6 +1005,7 @@ sub _get_defect_updates_resource {
             extras => { latest_data_only => 1 },
         );
 
+        $self->_add_extra_details($mapping->{extra_details}, $attributes, $args{extras}) if $mapping->{extra_details};
         $self->_apply_extra_attributes($extra_mapping, $attributes, $args{extras});
 
         push @updates, Open311::Endpoint::Service::Request::Update::mySociety->new( %args );

--- a/t/open311/endpoint/dumfries_alloy.t
+++ b/t/open311/endpoint/dumfries_alloy.t
@@ -428,7 +428,15 @@ subtest 'priority pulled through' => sub {
       "update_id" => "63ee34826965f30390f01cda_20251225120000",
       "extras" => {
          "latest_data_only" => 1,
-         "priority" => "Critical Risk"
+         "priority" => "Critical Risk",
+         "detailed_information" => <<HERE,
+Inspector's Description:
+Pothole in large category
+
+Inspection Outcome Notes:
+Fixed after a delay due to flooding of road
+
+HERE
       },
       "description" => "",
       "service_request_id" => "63ee34826965f30390f01cda"
@@ -459,6 +467,15 @@ subtest 'defect updates include priority from extra_attributes' => sub {
     is $defect_update->{status}, 'planned', 'Defect status is planned';
     is $defect_update->{extras}{priority}, '3 - 60 Working Days', 'Defect update includes priority from extra_attributes';
     is $defect_update->{extras}{latest_data_only}, 1, 'latest_data_only flag present';
+    is $defect_update->{extras}{detailed_information},
+"Inspector's Description:
+A large pothole
+
+Inspection Outcome Notes:
+Fixed after a delay due to hot weather
+
+",
+    'detailed_information added';
 };
 
 # See also t/open311/endpoint/alloy_deferred_work.t for async inspection upload tests.

--- a/t/open311/endpoint/dumfries_alloy.yml
+++ b/t/open311/endpoint/dumfries_alloy.yml
@@ -52,6 +52,9 @@ inspection_attribute_mapping:
   hwy_priority: attributes_hwyPriority
   se_priority: attributes_sePriority
   triage_priority: attributes_triagePriority
+  extra_details:
+    attributes_defectsDescription: Inspector's Description
+    attributes_defectsOutcomeNotes: Inspection Outcome Notes
   extra_attributes:
     priority: root.attributes_serviceEnquiryHWYPriority_652e86d3737fc1d2c84c720b.attributes_itemsTitle
 
@@ -165,6 +168,9 @@ defect_resource_name:
 defect_attribute_mapping:
   requested_datetime: attributes_defectsReportedDate
   status: attributes_defectsStatus
+  extra_details:
+    attributes_defectsDescription: Inspector's Description
+    attributes_defectsOutcomeNotes: Inspection Outcome Notes
   extra_attributes:
     priority:
       - root.attributes_defectTriagePriority.attributes_itemsTitle

--- a/t/open311/endpoint/json/alloyv2/dumfries/defect_updates_search.json
+++ b/t/open311/endpoint/json/alloyv2/dumfries/defect_updates_search.json
@@ -41,6 +41,14 @@
                 {
                     "attributeCode": "attributes_defectsReportedDate",
                     "value": "2025-12-25T10:00:00.000Z"
+                },
+                {
+                    "attributeCode": "attributes_defectsDescription",
+                    "value": "A large pothole"
+                },
+                {
+                    "attributeCode": "attributes_defectsOutcomeNotes",
+                    "value": "Fixed after a delay due to hot weather"
                 }
             ],
             "signature": "sig123"

--- a/t/open311/endpoint/json/alloyv2/dumfries/designs_serviceEnquiry_search.json
+++ b/t/open311/endpoint/json/alloyv2/dumfries/designs_serviceEnquiry_search.json
@@ -46,7 +46,15 @@
       "attributes": [
           { "attributeCode": "attributes_status", "value": ["1212aad"] },
           { "attributeCode": "attributes_outcome", "value": ["1234ade"] },
-          { "attributeCode": "attributes_hwyPriority", "value": ["987ffa"] }
+          { "attributeCode": "attributes_hwyPriority", "value": ["987ffa"] },
+          {
+            "attributeCode": "attributes_defectsDescription",
+            "value": "Pothole in large category"
+          },
+          {
+            "attributeCode": "attributes_defectsOutcomeNotes",
+            "value": "Fixed after a delay due to flooding of road"
+          }
       ],
       "signature": "63ee3490b016c303ae032113"
     },


### PR DESCRIPTION
Part of https://github.com/mysociety/societyworks/issues/5477.

Adapts current adding of specific alloy attributes to extra->{detailed_information} to allow multiple attributes to be added as suggests there are in request.

Corresponding FMS changes: https://github.com/mysociety/fixmystreet/pull/6026.

