### PR TITLE
[Northumberland] Questions on categories map to Alloy attributes

### DIFF
--- a/perllib/Open311/Endpoint/Integration/UK/NorthumberlandAlloy.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/NorthumberlandAlloy.pm
@@ -47,6 +47,7 @@ In addition to the default new request processing, this function:
 * Gets category and group codes from the provided data.
 * Looks up the category via C<category_list_code> and C<category_title_attribute>, adding this item under the 'category' attribute specified in C<request_to_resource_attribute_manual_mapping>.
 * Looks up the category via C<group_list_code> and C<group_title_attribute>, adding this item the 'group' attribute specified in C<request_to_resource_attribute_manual_mapping>.
+* Looks up attributes for extra questions for specific categories in C<request_to_resource_attribute_manual_mapping> and maps answers to the Alloy attributes
 
 =cut
 
@@ -59,6 +60,16 @@ sub process_attributes {
     push @$attributes, {
         attributeCode => $self->config->{contact}->{attribute_id},
         value => [ $contact_resource_id ],
+    };
+
+    if (my $mapping = $self->config->{request_to_resource_attribute_manual_mapping}{ $args->{service_code_alloy} }) {
+        for my $key ( keys %$mapping ) {
+            push @$attributes,
+              {
+               attributeCode => $mapping->{$key},
+               value => [ $args->{attributes}->{$key} ],
+              }
+          };
     };
 
     $self->_populate_category_and_group_attr(

--- a/perllib/Open311/Endpoint/Integration/UK/NorthumberlandAlloy.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/NorthumberlandAlloy.pm
@@ -68,7 +68,7 @@ sub process_attributes {
             push @$attributes,
               {
                attributeCode => $mapping->{$key},
-               value => [ $args->{attributes}->{$key} ],
+               value => $args->{attributes}->{$key},
               }
           };
     };

--- a/perllib/Open311/Endpoint/Integration/UK/NorthumberlandAlloy.pm
+++ b/perllib/Open311/Endpoint/Integration/UK/NorthumberlandAlloy.pm
@@ -64,6 +64,7 @@ sub process_attributes {
 
     if (my $mapping = $self->config->{request_to_resource_attribute_manual_mapping}{ $args->{service_code_alloy} }) {
         for my $key ( keys %$mapping ) {
+            next unless $args->{attributes}->{$key};
             push @$attributes,
               {
                attributeCode => $mapping->{$key},

--- a/t/open311/endpoint/northumberland_alloy.t
+++ b/t/open311/endpoint/northumberland_alloy.t
@@ -212,6 +212,7 @@ subtest "create basic problem" => sub {
         service_code => 'Damaged_/_Missing_/_Facing_Wrong_Way',
         'attribute[category]' => 'Damaged / Missing / Facing Wrong Way',
         'attribute[group]' => 'Street Lighting',
+        'attribute[Q1]' => 'Yes',
     );
     restore_time();
 
@@ -227,6 +228,7 @@ subtest "create basic problem" => sub {
             { attributeCode => 'attributes_customerRequestFMSSummary_63862bd505cb250393c204d7', value => "title" },
             { attributeCode => 'attributes_customerRequestFixMyStreetID_63862c38bafbd20397883f72', value => 123 },
             { attributeCode => 'attributes_customerRequestMainFMSStatus_63fcb297c9ec9c036ec35dfb', value => undef },
+            { attributeCode => 'attributes_customerRequestQuestion1_69931b1e554d8210415970e4', value => [ 'Yes' ]},
             { attributeCode => 'attributes_customerRequestReporter_63f4c227dabda80390d2f0ab', value => [ '6420576dac3acd036a974043' ]},
             { attributeCode => 'attributes_customerRequestRequestCategory_63862851fb3d97038c4e1cfc', value => [ '61fb016c4c5c56015448093f' ]},
             { attributeCode => 'attributes_customerRequestRequestGroup_638627f005cb250393c1705a', value => [ '61fafee3e3b879015205f7cb' ]},
@@ -378,6 +380,7 @@ subtest "create problem on groupless category" => sub {
             { attributeCode => 'attributes_customerRequestFMSSummary_63862bd505cb250393c204d7', value => "title" },
             { attributeCode => 'attributes_customerRequestFixMyStreetID_63862c38bafbd20397883f72', value => 123 },
             { attributeCode => 'attributes_customerRequestMainFMSStatus_63fcb297c9ec9c036ec35dfb', value => undef },
+            { attributeCode => 'attributes_customerRequestQuestion1_69931b1e554d8210415970e4', value => [ undef ]},
             { attributeCode => 'attributes_customerRequestReporter_63f4c227dabda80390d2f0ab', value => [ '6420576dac3acd036a974043' ]},
             { attributeCode => 'attributes_customerRequestRequestCategory_63862851fb3d97038c4e1cfc', value => [ '61fb016c4c5c56015448093f' ]},
             { attributeCode => 'attributes_customerRequestRequestGroup_638627f005cb250393c1705a', value => [ '61fafee3e3b879015205f7cb' ]},

--- a/t/open311/endpoint/northumberland_alloy.t
+++ b/t/open311/endpoint/northumberland_alloy.t
@@ -228,7 +228,7 @@ subtest "create basic problem" => sub {
             { attributeCode => 'attributes_customerRequestFMSSummary_63862bd505cb250393c204d7', value => "title" },
             { attributeCode => 'attributes_customerRequestFixMyStreetID_63862c38bafbd20397883f72', value => 123 },
             { attributeCode => 'attributes_customerRequestMainFMSStatus_63fcb297c9ec9c036ec35dfb', value => undef },
-            { attributeCode => 'attributes_customerRequestQuestion1_69931b1e554d8210415970e4', value => [ 'Yes' ]},
+            { attributeCode => 'attributes_customerRequestQuestion1_69931b1e554d8210415970e4', value => 'Yes' },
             { attributeCode => 'attributes_customerRequestReporter_63f4c227dabda80390d2f0ab', value => [ '6420576dac3acd036a974043' ]},
             { attributeCode => 'attributes_customerRequestRequestCategory_63862851fb3d97038c4e1cfc', value => [ '61fb016c4c5c56015448093f' ]},
             { attributeCode => 'attributes_customerRequestRequestGroup_638627f005cb250393c1705a', value => [ '61fafee3e3b879015205f7cb' ]},

--- a/t/open311/endpoint/northumberland_alloy.t
+++ b/t/open311/endpoint/northumberland_alloy.t
@@ -380,7 +380,6 @@ subtest "create problem on groupless category" => sub {
             { attributeCode => 'attributes_customerRequestFMSSummary_63862bd505cb250393c204d7', value => "title" },
             { attributeCode => 'attributes_customerRequestFixMyStreetID_63862c38bafbd20397883f72', value => 123 },
             { attributeCode => 'attributes_customerRequestMainFMSStatus_63fcb297c9ec9c036ec35dfb', value => undef },
-            { attributeCode => 'attributes_customerRequestQuestion1_69931b1e554d8210415970e4', value => [ undef ]},
             { attributeCode => 'attributes_customerRequestReporter_63f4c227dabda80390d2f0ab', value => [ '6420576dac3acd036a974043' ]},
             { attributeCode => 'attributes_customerRequestRequestCategory_63862851fb3d97038c4e1cfc', value => [ '61fb016c4c5c56015448093f' ]},
             { attributeCode => 'attributes_customerRequestRequestGroup_638627f005cb250393c1705a', value => [ '61fafee3e3b879015205f7cb' ]},

--- a/t/open311/endpoint/northumberland_alloy.yml
+++ b/t/open311/endpoint/northumberland_alloy.yml
@@ -162,6 +162,9 @@
   "request_to_resource_attribute_manual_mapping": {
     "category": "attributes_customerRequestRequestCategory_63862851fb3d97038c4e1cfc",
     "group": "attributes_customerRequestRequestGroup_638627f005cb250393c1705a",
+    "Damaged / Missing / Facing Wrong Way": {
+      "Q1": "attributes_customerRequestQuestion1_69931b1e554d8210415970e4",
+    },
   },
 
   "inspection_attribute_mapping": {


### PR DESCRIPTION
Where a category has extra questions in FMS, allow these answers to be mapped via configuration in 'request_to_resource_attribute_manual_mapping' to Alloy attributes.

https://mysocietysupport.freshdesk.com/a/tickets/7248